### PR TITLE
fix spelling: defaut -> default

### DIFF
--- a/src/osw_ui_util.cpp
+++ b/src/osw_ui_util.cpp
@@ -7,9 +7,9 @@ void print2Digits(OswHal* hal, long n) {
   hal->getCanvas()->print(n);
 }
 
-uint16_t defaultFontXOffset(uint16_t numChars, uint16_t scale) {  // works with defaut font only
+uint16_t defaultFontXOffset(uint16_t numChars, uint16_t scale) {  // works with default font only
   return numChars * 6 * scale;
 }
-uint16_t defaultFontYOffset(uint16_t numRows, uint16_t scale) {  // works with defaut font only
+uint16_t defaultFontYOffset(uint16_t numRows, uint16_t scale) {  // works with default font only
   return numRows * 8 * scale;
 }


### PR DESCRIPTION
Here is a useless PR that fixes a spelling mistake in a comment.