### PR TITLE
BluetoothLE Service for Companion App

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -19,4 +19,6 @@
 #define MINI_IOT_DEVICENAME "yourDeviceName"
 #define MINI_IOT_SERVER "yourMiniIotServerIp:port"
 
+#define BLE_DEVICE_NAME DEVICE_NAME
+
 #endif

--- a/include/osw_service.h
+++ b/include/osw_service.h
@@ -1,0 +1,6 @@
+#ifndef OSW_SERVICE_H
+#define OSW_SERVICE_H
+    #include <osw_app.h>
+
+    typedef OswApp OswService;
+#endif

--- a/include/services/companionservice.h
+++ b/include/services/companionservice.h
@@ -1,0 +1,44 @@
+#ifndef OSW_SERVICE_COMPANION_H
+#define OSW_SERVICE_COMPANION_H
+
+#include <BLECharacteristic.h>
+#include <BLEDevice.h>
+#include <osw_hal.h>
+#include <functional>
+#include <string>
+
+#include "osw_service.h"
+
+#define NOTIFICATION_SERVICE_UID "30412632-6339-46e3-ad9e-bcfa9a766854"
+
+#define NOTIFICATION_BRDCST_CHAR "23dac1dc-ca00-47ed-a5fa-e3b9da959685"
+
+typedef struct NotificationDetails {
+    unsigned int uid;
+    std::string app;
+    std::string contents;
+};
+
+class OswServiceCompanion : public OswService {
+    public:
+        OswServiceCompanion(void){};
+        void setup(OswHal* hal);
+        void loop(OswHal* hal);
+        void stop(OswHal* hal);
+        ~OswServiceCompanion(){};
+
+        void setNotificationCallback(std::function<void(NotificationDetails)> cb);
+        void startAdvertising();
+        void stopAdvertising();
+
+    private:
+        BLEServer* bleServer = NULL;
+        BLEService* notificationService = NULL;
+        BLECharacteristic* notificationChar = NULL;
+
+        std::function<void(NotificationDetails)> notificationCallback;
+
+        friend class NotificationCallback;
+};
+
+#endif

--- a/include/services/servicemanager.h
+++ b/include/services/servicemanager.h
@@ -1,0 +1,35 @@
+#ifndef OSW_SERVICE_MANAGER_H
+#define OSW_SERVICE_MANAGER_H
+#include "osw_service.h"
+#include "osw_hal.h"
+#include <vector>
+
+
+class OswServiceManager {
+    public:
+        static OswServiceManager &getInstance() {
+            static OswServiceManager instance;
+            return instance;
+        }
+
+        void registerService(int serviceId, OswService *service);
+        OswService *getService(int serviceId);
+
+        void setup(OswHal *hal);
+        void loop(OswHal *hal);
+        void stop(OswHal *hal);
+
+    private:
+        OswServiceManager(): serviceRegistry() {};
+
+        OswServiceManager(OswServiceManager const&);
+        void operator=(OswServiceManager const&);
+
+        struct Service {
+            int id;
+            OswService *service;
+        };
+        
+        std::vector<Service> serviceRegistry; 
+};
+#endif

--- a/include/services/services.h
+++ b/include/services/services.h
@@ -1,0 +1,3 @@
+enum Services {
+    BLUETOOTH_COMPANION_SERVICE
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ lib_deps =
 	adafruit/Adafruit Unified Sensor@^1.1.4
 	adafruit/Adafruit BME280 Library@^2.1.1
 	makuna/RTC@^2.3.5
+	bblanchon/ArduinoJson@^6.17.3
 build_flags = 
 	-D DEBUG=1
 	-D ARDUINO_ESP32_PICO

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,6 +41,7 @@ lib_deps =
 	adafruit/Adafruit Unified Sensor@^1.1.4
 	adafruit/Adafruit BME280 Library@^2.1.1
 	makuna/RTC@^2.3.5
+	bblanchon/ArduinoJson@^6.17.3
 build_flags = 
 	-D DEBUG=1
 	-D GPS_EDITION    

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,9 @@
 #if defined(GPS_EDITION)
 #include "./apps/main/map.h"
 #endif
+#include "./services/companionservice.h"
+#include "./services/servicemanager.h"
+#include "services/services.h"
 
 OswHal *hal = new OswHal();
 // OswAppRuntimeTest *runtimeTest = new OswAppRuntimeTest();
@@ -57,6 +60,13 @@ void backgroundLoop(void *pvParameters) {
 
 void IRAM_ATTR isrStepDetect() { Serial.println("Step"); }
 
+void registerSystemServices() {
+  //Register system services
+  OswServiceManager &serviceManager = OswServiceManager::getInstance();
+
+  serviceManager.registerService(Services::BLUETOOTH_COMPANION_SERVICE, new OswServiceCompanion());
+}
+
 void setup() {
   Serial.begin(115200);
 
@@ -91,6 +101,11 @@ void setup() {
 
 #endif
 
+  //Register system services
+  registerSystemServices();
+
+  OswServiceManager &serviceManager = OswServiceManager::getInstance();
+  serviceManager.setup(hal); //Services should always start before apps do
   mainApps[appPtr]->setup(hal);
 }
 
@@ -116,6 +131,9 @@ void loop() {
     appPtr %= NUM_APPS;
     mainApps[appPtr]->setup(hal);
   }
+
+  OswServiceManager &serviceManager = OswServiceManager::getInstance();
+  serviceManager.loop(hal); 
 
   mainApps[appPtr]->loop(hal);
   // runtimeTest->loop(hal);

--- a/src/services/companionservice.cpp
+++ b/src/services/companionservice.cpp
@@ -1,0 +1,89 @@
+#include "./services/companionservice.h"
+#include "osw_hal.h"
+
+#include <BLEDevice.h>
+#include <BLEUtils.h>
+#include <BLEServer.h>
+#include <BLECharacteristic.h>
+#include <ArduinoJson.h>
+
+#include <string.h>
+#include "config.h"
+
+
+class NotificationCallback: public BLECharacteristicCallbacks {
+    public:
+        NotificationCallback(OswServiceCompanion *comp) {
+            companion = comp;
+        }
+
+        virtual ~NotificationCallback() {};
+
+        virtual void onRead(BLECharacteristic* pCharacteristic) {};
+        virtual void onWrite(BLECharacteristic* pCharacteristic) {
+            //Parse message as JSON object
+            Serial.println(pCharacteristic->getValue().c_str());
+            DynamicJsonDocument doc(5000); //ArduinoJSON no longer allows Dynamic allocation to grow
+
+            deserializeJson(doc, pCharacteristic->getValue());
+
+            //Pull values from JSON
+            const char *app = "", *contents = "";
+            unsigned int uid = 0;
+
+            if (doc.containsKey("app"))
+                app = doc["app"];
+
+            if (doc.containsKey("contents"))
+                contents = doc["contents"];
+
+            if (doc.containsKey("uid"))
+                uid = doc["uid"];
+
+            NotificationDetails details {uid, app, contents};
+
+            //Notify our client about the new notificaiton
+            if (companion->notificationCallback) {
+                companion->notificationCallback(details);
+            }
+        };
+
+        virtual void onNotify(BLECharacteristic* pCharacteristic) {};
+        virtual void onStatus(BLECharacteristic* pCharacteristic, Status s, uint32_t code) {};
+
+    private:
+        OswServiceCompanion *companion;
+};
+
+void OswServiceCompanion::setup(OswHal* hal) {
+    BLEDevice::init(BLE_DEVICE_NAME);
+    bleServer = BLEDevice::createServer();
+    notificationService = bleServer->createService(NOTIFICATION_SERVICE_UID);
+
+    notificationChar = notificationService->createCharacteristic(NOTIFICATION_BRDCST_CHAR, BLECharacteristic::PROPERTY_WRITE);
+    notificationChar->setCallbacks(new NotificationCallback(this));
+
+    notificationService->start();
+
+    bleServer->getAdvertising()->addServiceUUID(notificationService->getUUID());
+}
+
+void OswServiceCompanion::startAdvertising() {
+    bleServer->startAdvertising();
+}
+
+void OswServiceCompanion::stopAdvertising() {
+    bleServer->getAdvertising()->stop()
+}
+
+void OswServiceCompanion::setNotificationCallback(std::function<void(NotificationDetails)> cb) {
+    notificationCallback = cb;
+}
+
+void OswServiceCompanion::loop(OswHal* hal) {
+    
+}
+
+void OswServiceCompanion::stop(OswHal* hal) {
+    
+}

--- a/src/services/companionservice.cpp
+++ b/src/services/companionservice.cpp
@@ -73,7 +73,7 @@ void OswServiceCompanion::startAdvertising() {
 }
 
 void OswServiceCompanion::stopAdvertising() {
-    bleServer->getAdvertising()->stop()
+    bleServer->getAdvertising()->stop();
 }
 
 void OswServiceCompanion::setNotificationCallback(std::function<void(NotificationDetails)> cb) {

--- a/src/services/servicemanager.cpp
+++ b/src/services/servicemanager.cpp
@@ -1,0 +1,36 @@
+#include "./services/servicemanager.h"
+
+void OswServiceManager::registerService(int serviceId, OswService *service) {
+    if (!getService(serviceId)) {
+        Service svc = {serviceId, service};
+        serviceRegistry.push_back(svc);
+    }
+}
+
+void OswServiceManager::setup(OswHal *hal) {
+    for (std::vector<Service>::iterator it = serviceRegistry.begin() ; it != serviceRegistry.end(); ++it) {
+        return it->service->setup(hal);
+    }
+}
+
+void OswServiceManager::loop(OswHal *hal) {
+    for (std::vector<Service>::iterator it = serviceRegistry.begin() ; it != serviceRegistry.end(); ++it) {
+        return it->service->loop(hal);
+    }
+}
+
+void OswServiceManager::stop(OswHal *hal) {
+    for (std::vector<Service>::iterator it = serviceRegistry.begin() ; it != serviceRegistry.end(); ++it) {
+        return it->service->stop(hal);
+    }
+}
+
+OswService *OswServiceManager::getService(int serviceId) {
+    for (std::vector<Service>::iterator it = serviceRegistry.begin() ; it != serviceRegistry.end(); ++it) {
+        if (it->id == serviceId) {
+            return it->service;
+        }
+    }
+
+    return NULL;
+}


### PR DESCRIPTION
Basic Bluetooth service for companion app and Notifications. I'm hoping this will be a good start to allowing the watch to pair to a Smartphone and integration.
 

- Creates framework for background services which are always running. Apps are able to lookup a service to call methods on them
- Sets up a Bluetooth LE watch service that can be advertised
- Adds a LE Characteristic for Notifications
- Uses ArduinoJSON to deserialize LE packet into notification details
- Sends callback to client about new notification


Repo for the companion app can be found here: https://github.com/SeanReg/open-smartwatch-android-companion

Companion app is very basic. 

Right now it will do the following:

- Scan for the Open Smartwatch service and store the first discovered device's MAC
- Setup GATT connection to device 
- Listen for Android Notifications
- Extract details from Android Notifications and will send to Open Smartwatch if Connected


When I tested locally I just started Advertising from the watch at boot  and had logging whenever a notification was received to validate it works. That test code has been from my commit.

Two things that might be good next steps:
- I'm not sure serializing as JSON was the best idea. Maybe something like protobuf would be better? I don't like that ArduinoJSON's DynamicJsonDocument can't grow past the given capacity.
- Enabling Security on the Bluetooth LE link. This will require a pairing process to occur prior to Notification exchanges but will Encrypt the BLE communication.

Let me know if you have any questions. 