### PR TITLE
Force run the GC every loop

### DIFF
--- a/src/apps/main/luaapp.cpp
+++ b/src/apps/main/luaapp.cpp
@@ -31,6 +31,9 @@ void OswLuaApp::loop(OswHal* hal) {
         if (lua_pcall(luaState, 0, 0, 0)) {
             Serial.println("Failed to call loop"); 
         }
+
+        //Force GC to run after loop
+        lua_gc(luaState, LUA_GCCOLLECT, 0);
     }
 }
 


### PR DESCRIPTION
Force running the Garbage collector after loop function call because it can't keep up with allocations.

@uvwxy 
Mind testing this with the StopWatch Lua example? This *should* fix the crash 

