### PR TITLE
swapping apps should reset screen on time

### DIFF
--- a/include/osw_hal.h
+++ b/include/osw_hal.h
@@ -46,6 +46,7 @@ class OswHal {
   void requestEnableDisplayBuffer();
   void disableDisplayBuffer();
   void enableDisplayBuffer();
+  void resetScreenOnTime();
   unsigned long screenOnTime();
   unsigned long screenOffTime();
 

--- a/src/hal/display.cpp
+++ b/src/hal/display.cpp
@@ -61,6 +61,10 @@ void OswHal::displayOff(void) {
   _screenOffSince = millis();
 }
 
+void OswHal::resetScreenOnTime() {
+  _screenOnSince = millis();
+}
+
 unsigned long OswHal::screenOnTime() { return millis() - _screenOnSince; }
 unsigned long OswHal::screenOffTime() { return millis() - _screenOffSince; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,6 +132,7 @@ void loop() {
   if (hal->btn1Down() >= BTN_1_APP_SWITCH_TIMEOUT) {
     // switch app
     mainApps[appPtr]->stop(hal);
+    hal->resetScreenOnTime();
     appPtr++;
     appPtr %= NUM_APPS;
     mainApps[appPtr]->setup(hal);


### PR DESCRIPTION
I thought the watch app was crashing on app swapping, but it turns out that it's just immediately turning itself off (because the screen's been "on" since it was last focused). Let's reset the screen "on" time each time an app is swapped.