### PR TITLE
Python Install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .DS_Store
 firmware.elf
+bin

--- a/install.py
+++ b/install.py
@@ -1,0 +1,40 @@
+import requests
+import os
+import tarfile
+import platform
+
+SWIG_LINUX_VERSION = '4.0.1-5build1'
+SWIG_URL = "https://anaconda.org/anaconda/swig/4.0.2/download/win-64/swig-4.0.2-hd77b12b_3.tar.bz2"
+SWIG_PATH = "bin/swig"
+SWIG_TAR = "swig.tar.bz2"
+SWIG_TAR_PATH = os.path.join(SWIG_PATH, SWIG_TAR)
+
+def installSwigWindows():
+    print("Create directory")
+    os.makedirs(SWIG_PATH, exist_ok=True)
+
+    print("Downloading SWIG...")
+    res = requests.get(SWIG_URL)
+    with open(SWIG_TAR_PATH, 'wb') as outfile:
+        outfile.write(res.content)
+
+    print("Extracting...")
+    tar = tarfile.open(SWIG_TAR_PATH, "r:bz2")
+    tar.extractall(SWIG_PATH)
+    tar.close()
+
+    print("Cleaning up...")
+    os.unlink(SWIG_TAR_PATH)
+
+def installSwigLinux():
+    os.system('sudo apt-get update')
+    os.system(f'sudo apt-get install swig={SWIG_LINUX_VERSION}')
+
+if (platform.system() == "Windows"):
+    installSwigWindows()
+elif (platform.system() == "Linux"):
+    installSwigLinux()
+else:
+    print(f"{platform.system()} not supported")
+
+print("Done")

--- a/prebuild.py
+++ b/prebuild.py
@@ -2,6 +2,7 @@ Import("env")
 import subprocess
 import sys
 import os
+import platform
 
 print("Building osw_wrap.cxx with swig..")
 
@@ -14,7 +15,22 @@ def getPlatformCore(env):
     
     return os.path.join(os.path.join(os.path.join(packagesDir, f"framework-{framework}{platform}"), "cores"), board)
 
-process = subprocess.Popen(['swig', '-c++', '-lua', '-I../../include', '-I../../lib/Arduino_GFX', f'-I{getPlatformCore(env)}', "-v", 'osw.i'], cwd=r'./src/swig')
+def getSwigPath():
+    path = "swig"
+    
+    #Attempt to use swig.exe from install.py
+    windowsPath = os.path.join("bin", "swig")
+    exe = "swig.exe"
+    if (platform.system() == "Windows"):
+        if (os.path.exists(windowsPath)):
+            #Search for swig.exe
+            for root, subdirs, files in os.walk(windowsPath):
+                if (exe in files):
+                    return os.path.join(root, exe)
+    
+    return path
+
+process = subprocess.Popen([getSwigPath(), '-c++', '-lua', '-I../../include', '-I../../lib/Arduino_GFX', f'-I{getPlatformCore(env)}', "-v", 'osw.i'], cwd=r'./src/swig')
 
 process.wait()
 return_code = process.poll()

--- a/src/swig/osw.i
+++ b/src/swig/osw.i
@@ -59,6 +59,7 @@ void halToLua(lua_State *L, OswHal *hal) {
 
 #define __attribute__(x)
 
+%include <std_string.i>
 %include "stdint.i"
 %include "Print.h"
 %include "osw_hal.h"


### PR DESCRIPTION
Python install script. Users can run to setup any build tool dependencies. Currently will install SWIG.

- For windows, Download swig.exe from anaconda packages and unpacks it locally. This .exe will be used during the prebuild script so will not need to add to PATH
- For Linux, runs `apt-get install` with a specific version of SWIG