### PR TITLE
Prevent Deepsleep while buttons are pressed

### DIFF
--- a/src/apps/main/switcher.cpp
+++ b/src/apps/main/switcher.cpp
@@ -49,9 +49,13 @@ void OswAppSwitcher::loop(OswHal* hal) {
 
   if (_enableAutoSleep && *_rtcAppIndex == 0 && !hal->btnIsDown(_btn)) {
     if (*_rtcAppIndex == 0 && (millis() - appOnScreenSince) > 15000) {
-      hal->gfx()->fill(rgb565(0, 0, 0));
-      hal->flushCanvas();
-      hal->deepSleep();
+      if(hal->btnIsDown(BUTTON_1) || hal->btnIsDown(BUTTON_2) || hal->btnIsDown(BUTTON_3)){
+        appOnScreenSince = millis();
+      }else{
+        hal->gfx()->fill(rgb565(0, 0, 0));
+        hal->flushCanvas();
+        hal->deepSleep();
+      }
     }
   }
 


### PR DESCRIPTION
If the deepsleep gets triggered while a button is pressed, we reset the screentime for the app.
This should avoid deepsleep while we do stuff on the watch :)
