### PR TITLE
Allowing on-device brightness updates

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -21,7 +21,7 @@
 #define DEVICE_NAME "yourDeviceName"
 #define BLE_DEVICE_NAME DEVICE_NAME
 
-
+#define DISPLAY_MIN_BRIGHTNESS 10
 
 // The following settings are configureable later on using the web ui, you can still set the defaults here.
 

--- a/include/osw_config_keys.h
+++ b/include/osw_config_keys.h
@@ -35,6 +35,7 @@ extern OswConfigKeyShort settingDisplayTimeout;
 extern OswConfigKeyShort settingDisplayBrightness;
 extern OswConfigKeyBool settingDisplayOverlays;
 extern OswConfigKeyBool settingDisplayOverlaysOnWatchScreen;
+extern OswConfigKeyShort settingDisplayMinBrightness;
 extern OswConfigKeyBool raiseToWakeEnabled;
 extern OswConfigKeyShort raiseToWakeSensitivity;
 extern OswConfigKeyBool tapToWakeEnabled;

--- a/include/osw_config_keys.h
+++ b/include/osw_config_keys.h
@@ -35,7 +35,6 @@ extern OswConfigKeyShort settingDisplayTimeout;
 extern OswConfigKeyShort settingDisplayBrightness;
 extern OswConfigKeyBool settingDisplayOverlays;
 extern OswConfigKeyBool settingDisplayOverlaysOnWatchScreen;
-extern OswConfigKeyShort settingDisplayMinBrightness;
 extern OswConfigKeyBool raiseToWakeEnabled;
 extern OswConfigKeyShort raiseToWakeSensitivity;
 extern OswConfigKeyBool tapToWakeEnabled;

--- a/src/hal/display.cpp
+++ b/src/hal/display.cpp
@@ -69,6 +69,7 @@ void OswHal::displayOn(void) {
 #ifdef ESP32
   ledcAttachPin(TFT_LED, 1);
   ledcSetup(1, 12000, 8);  // 12 kHz PWM, 8-bit resolution
+  setBrightness(OswConfigAllKeys::settingDisplayBrightness.get());
 #else
   pinMode(TFT_LED, OUTPUT);
 #endif
@@ -79,6 +80,12 @@ void OswHal::setBrightness(uint8_t b) {
   _brightness = b;
 #ifdef ESP32
   ledcWrite(1, _brightness);
+  OswConfig::getInstance()->enableWrite();
+  OswConfigAllKeys::settingDisplayBrightness.set(_brightness);
+  OswConfig::getInstance()->disableWrite();
+#ifdef DEBUG
+  Serial.println("Setting brightness to "+ String(b));
+#endif
 #else
   digitalWrite(TFT_LED, brightness);
 #endif
@@ -94,8 +101,12 @@ void OswHal::increaseBrightness(uint8_t v) {
 };
 
 void OswHal::decreaseBrightness(uint8_t v) {
-  if (_brightness < v) {
-    _brightness = 0;
+  short minBrightness = OswConfigAllKeys::settingDisplayMinBrightness.get();
+  if (minBrightness < 0) {
+    minBrightness = 0;
+  }
+  if ((_brightness - v) < minBrightness) {
+    _brightness = minBrightness;
   } else {
     _brightness -= v;
   }

--- a/src/hal/display.cpp
+++ b/src/hal/display.cpp
@@ -101,7 +101,10 @@ void OswHal::increaseBrightness(uint8_t v) {
 };
 
 void OswHal::decreaseBrightness(uint8_t v) {
-  short minBrightness = OswConfigAllKeys::settingDisplayMinBrightness.get();
+  short minBrightness = 0;
+#ifdef DISPLAY_MIN_BRIGHTNESS
+  minBrightness = DISPLAY_MIN_BRIGHTNESS;
+#endif
   if (minBrightness < 0) {
     minBrightness = 0;
   }

--- a/src/hal/power.cpp
+++ b/src/hal/power.cpp
@@ -84,7 +84,6 @@ void doSleep(OswHal* hal, bool deepSleep, long millis = 0) {
 #endif
 
   // turn off screen
-  hal->setBrightness(0);
   hal->displayOff();
 
   // register user wakeup sources

--- a/src/hal/power.cpp
+++ b/src/hal/power.cpp
@@ -79,8 +79,8 @@ void OswHal::setCPUClock(uint8_t mhz) {
 void doSleep(OswHal* hal, bool deepSleep, long millis = 0) {
   // turn off gps (this needs to be able to prohibited by app)
 #if defined(GPS_EDITION)
-  this->gpsBackupMode();
-  this->sdOff();
+  hal->gpsBackupMode();
+  hal->sdOff();
 #endif
 
   // turn off screen

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,6 @@ void setup() {
   hal->setupTime();
 
   hal->setupDisplay();
-  hal->setBrightness(OswConfigAllKeys::settingDisplayBrightness.get());
 
   mainAppSwitcher->setup(hal);
 

--- a/src/osw_config.cpp
+++ b/src/osw_config.cpp
@@ -139,7 +139,7 @@ void OswConfig::parseDataJSON(const char* json) {
   JsonArray entries = config["entries"].as<JsonArray>();
 
   for (auto it = entries.begin(); it != entries.end(); ++it) {
-    // Now find the corrent config key instance
+    // Now find the current config key instance
     JsonObject entry = it->as<JsonObject>();
     OswConfigKey* key = nullptr;
     String entryId = entry["id"];

--- a/src/osw_config_keys.cpp
+++ b/src/osw_config_keys.cpp
@@ -17,7 +17,6 @@ OswConfigKeyShort settingDisplayTimeout("s2", "Energy Settings", "Display Timeou
 OswConfigKeyBool settingDisplayOverlays("s3", "Energy Settings", "Display Overlays", "Show overlays (at all)", true);
 OswConfigKeyBool settingDisplayOverlaysOnWatchScreen("s4", "Energy Settings", "Display Watchface Overlays",
                                                      "Show overlays on watchfaces", false);
-
 OswConfigKeyBool raiseToWakeEnabled("s5", "Energy Settings", "Raise/Tilt to Wake", "Enables Raise to Wake", false);
 OswConfigKeyShort raiseToWakeSensitivity("s6", "Energy Settings", "Raise to Wake Sensitivity",
                                          "TBD - experiment (8bit, 1 LSB = 8mg)", 127);
@@ -25,6 +24,7 @@ OswConfigKeyBool lightSleepEnabled("s7", "Energy Settings", "Light Sleep", "Use 
                                    false);
 OswConfigKeyBool tapToWakeEnabled("s8", "Energy Settings", "Tap to Wake",
                                   "Enables Tap to Wake (If you select none, button 1 will wake the watch)", true);
+OswConfigKeyShort settingDisplayMinBrightness("s9", "Energy Settings", "Display Minimum Brightness","Manual brightness adjustments made on-device will not fall below this value.", 10);
 
 OswConfigKeyRGB themeBackgroundColor("c1", "Theme & UI", "Background color", nullptr, rgb888(0, 0, 0));
 OswConfigKeyRGB themeBackgroundDimmedColor("c8", "Theme & UI", "Background color (dimmed)", nullptr,
@@ -47,7 +47,7 @@ OswConfigKeyShort timeZone("h", "Date & Time", "Timezone", "Number of offset hou
 }  // namespace OswConfigAllKeys
 
 // ...and also here, if you want to load them during boot and make them available in the configuration ui
-const unsigned char oswConfigKeysCount = 23;  // <------------- DON'T FORGET THIS ONE IF YOU EDIT BELOW ;)
+const unsigned char oswConfigKeysCount = 24;  // <------------- DON'T FORGET THIS ONE IF YOU EDIT BELOW ;)
 OswConfigKey* oswConfigKeys[] = {
     // wifi (2)
     &OswConfigAllKeys::wifiSsid, &OswConfigAllKeys::wifiPass,
@@ -56,6 +56,7 @@ OswConfigKey* oswConfigKeys[] = {
     &OswConfigAllKeys::settingDisplayOverlays, &OswConfigAllKeys::settingDisplayOverlaysOnWatchScreen,
     &OswConfigAllKeys::raiseToWakeEnabled, &OswConfigAllKeys::raiseToWakeSensitivity,
     &OswConfigAllKeys::tapToWakeEnabled, &OswConfigAllKeys::lightSleepEnabled,
+    &OswConfigAllKeys::settingDisplayMinBrightness,
     // date + time (4)
     &OswConfigAllKeys::dateFormat, &OswConfigAllKeys::daylightOffset,  //
     &OswConfigAllKeys::timeZone, &OswConfigAllKeys::timeFormat,        //

--- a/src/osw_config_keys.cpp
+++ b/src/osw_config_keys.cpp
@@ -24,7 +24,6 @@ OswConfigKeyBool lightSleepEnabled("s7", "Energy Settings", "Light Sleep", "Use 
                                    false);
 OswConfigKeyBool tapToWakeEnabled("s8", "Energy Settings", "Tap to Wake",
                                   "Enables Tap to Wake (If you select none, button 1 will wake the watch)", true);
-OswConfigKeyShort settingDisplayMinBrightness("s9", "Energy Settings", "Display Minimum Brightness","Manual brightness adjustments made on-device will not fall below this value.", 10);
 
 OswConfigKeyRGB themeBackgroundColor("c1", "Theme & UI", "Background color", nullptr, rgb888(0, 0, 0));
 OswConfigKeyRGB themeBackgroundDimmedColor("c8", "Theme & UI", "Background color (dimmed)", nullptr,
@@ -47,7 +46,7 @@ OswConfigKeyShort timeZone("h", "Date & Time", "Timezone", "Number of offset hou
 }  // namespace OswConfigAllKeys
 
 // ...and also here, if you want to load them during boot and make them available in the configuration ui
-const unsigned char oswConfigKeysCount = 24;  // <------------- DON'T FORGET THIS ONE IF YOU EDIT BELOW ;)
+const unsigned char oswConfigKeysCount = 23;  // <------------- DON'T FORGET THIS ONE IF YOU EDIT BELOW ;)
 OswConfigKey* oswConfigKeys[] = {
     // wifi (2)
     &OswConfigAllKeys::wifiSsid, &OswConfigAllKeys::wifiPass,
@@ -56,7 +55,6 @@ OswConfigKey* oswConfigKeys[] = {
     &OswConfigAllKeys::settingDisplayOverlays, &OswConfigAllKeys::settingDisplayOverlaysOnWatchScreen,
     &OswConfigAllKeys::raiseToWakeEnabled, &OswConfigAllKeys::raiseToWakeSensitivity,
     &OswConfigAllKeys::tapToWakeEnabled, &OswConfigAllKeys::lightSleepEnabled,
-    &OswConfigAllKeys::settingDisplayMinBrightness,
     // date + time (4)
     &OswConfigAllKeys::dateFormat, &OswConfigAllKeys::daylightOffset,  //
     &OswConfigAllKeys::timeZone, &OswConfigAllKeys::timeFormat,        //


### PR DESCRIPTION
Adding new config value - minimum brightness. This is to prevent the user from setting the brightness to 0 on accident and forgetting about it. The minimum can be changed to 0 if the user would like to be able to set the brightness to 0. This change persists the brightness the user selects on-device. Might be nice to introduce some kind of helper method or something in OswConfig that handles enableWrite and disableWrite for reducing repetitive code.

Tested working fine thus far.