### PR TITLE
Issue 131 - configuration button press to wake - default on

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -38,4 +38,7 @@
 #define SERVICE_BLE_COMPANION 0
 #define SERVICE_RAW_SCREEN 0
 
+// Buttons wake up watch (default is true)
+#define SLEEP_BUTTONWAKE 1
+
 #endif

--- a/include/osw_config_keys.h
+++ b/include/osw_config_keys.h
@@ -43,6 +43,7 @@ extern OswConfigKeyBool raiseToWakeEnabled;
 extern OswConfigKeyShort raiseToWakeSensitivity;
 extern OswConfigKeyBool tapToWakeEnabled;
 extern OswConfigKeyBool lightSleepEnabled;
+extern OswConfigKeyBool buttonToWakeEnabled;
 extern OswConfigKeyDropDown dateFormat;
 extern OswConfigKeyFloat daylightOffset;
 extern OswConfigKeyBool timeFormat;

--- a/src/apps/main/switcher.cpp
+++ b/src/apps/main/switcher.cpp
@@ -41,7 +41,7 @@ void OswAppSwitcher::loop(OswHal* hal) {
   if (hal->btnHasGoneUp(_btn)) {
     if (_doSleep) {
       _doSleep = false;
-      sleep(hal, true);
+      sleep(hal, OswConfigAllKeys::buttonToWakeEnabled.get());
     }
     if (_doSwitch) {
       _doSwitch = false;
@@ -60,7 +60,7 @@ void OswAppSwitcher::loop(OswHal* hal) {
       } else if(timeout > 0) {
         Serial.print("Going to sleep after ");
         Serial.println(timeout);
-        sleep(hal, false);
+        sleep(hal, OswConfigAllKeys::buttonToWakeEnabled.get());
       }
     }
   }
@@ -168,7 +168,7 @@ void OswAppSwitcher::paginationEnable() {
 void OswAppSwitcher::sleep(OswHal* hal, boolean fromButton) {
   hal->gfx()->fill(rgb565(0, 0, 0));
   hal->flushCanvas();
-
+  
   if (fromButton) {
     hal->deepSleep(0, true /* force wakeup via button */);
   }

--- a/src/apps/main/switcher.cpp
+++ b/src/apps/main/switcher.cpp
@@ -168,7 +168,7 @@ void OswAppSwitcher::paginationEnable() {
 void OswAppSwitcher::sleep(OswHal* hal, boolean fromButton) {
   hal->gfx()->fill(rgb565(0, 0, 0));
   hal->flushCanvas();
-  
+
   if (fromButton) {
     hal->deepSleep(0, true /* force wakeup via button */);
   }

--- a/src/osw_config_keys.cpp
+++ b/src/osw_config_keys.cpp
@@ -29,7 +29,7 @@ OswConfigKeyBool lightSleepEnabled("s7", "Energy Settings", "Light Sleep", "Use 
                                    false);
 OswConfigKeyBool tapToWakeEnabled("s8", "Energy Settings", "Tap to Wake",
                                   "Enables Tap to Wake (If you select none, button 1 will wake the watch)", true);
-OswConfigKeyBool buttonToWakeEnabled("m","Energy Settings","Button to Wake","Enables Button to wake",SLEEP_BUTTONWAKE);
+OswConfigKeyBool buttonToWakeEnabled("m", "Energy Settings", "Button to Wake", "Enables Button to wake", SLEEP_BUTTONWAKE);
 
 OswConfigKeyRGB themeBackgroundColor("c1", "Theme & UI", "Background color", nullptr, rgb888(0, 0, 0));
 OswConfigKeyRGB themeBackgroundDimmedColor("c8", "Theme & UI", "Background color (dimmed)", nullptr,

--- a/src/osw_config_keys.cpp
+++ b/src/osw_config_keys.cpp
@@ -29,6 +29,7 @@ OswConfigKeyBool lightSleepEnabled("s7", "Energy Settings", "Light Sleep", "Use 
                                    false);
 OswConfigKeyBool tapToWakeEnabled("s8", "Energy Settings", "Tap to Wake",
                                   "Enables Tap to Wake (If you select none, button 1 will wake the watch)", true);
+OswConfigKeyBool buttonToWakeEnabled("m","Energy Settings","Button to Wake","Enables Button to wake",SLEEP_BUTTONWAKE);
 
 OswConfigKeyRGB themeBackgroundColor("c1", "Theme & UI", "Background color", nullptr, rgb888(0, 0, 0));
 OswConfigKeyRGB themeBackgroundDimmedColor("c8", "Theme & UI", "Background color (dimmed)", nullptr,


### PR DESCRIPTION
#131 - on sleep - button presses wake up watch from sleep by default; config.h can change this behavior to turn off.
Already a feature within develop codebase, simply exposing as config.h item and consuming in switcher.cpp