### PR TITLE
Fix German translation de-DE continue "Fortsetzen"

### DIFF
--- a/include/locales/de-DE.h
+++ b/include/locales/de-DE.h
@@ -20,7 +20,7 @@
 #define LANG_STW_START "Start"
 #define LANG_STW_STOP "Stopp"
 #define LANG_STW_RESET "Reset"
-#define LANG_STW_CONTINUE "Forsetzen"
+#define LANG_STW_CONTINUE "Fortsetzen"
 
 // Weekdays
 #define LANG_MONDAY "Montag"


### PR DESCRIPTION
Hi @uvwxy 
I've got my first two OSW PCBs this week and want to support the work on this project. To get started I fixed a typo in the german translation.