### PR TITLE
fixes issue #174

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ lib_deps =
 	mprograms/QMC5883LCompass@^1.1.1
 	adafruit/Adafruit Unified Sensor@^1.1.4
 	adafruit/Adafruit BME280 Library@^2.1.1
-	adafruit/Adafruit BusIO@^1.8.3
+	adafruit/Adafruit BusIO@^1.8.3,!=1.9.7
 	makuna/RTC@^2.3.5
 	bblanchon/ArduinoJson@^6.17.3
 	finitespace/BME280@^3.0.0


### PR DESCRIPTION
excludes AdafruitBusIO version 1.9.7 which is incompatible with 1.x.x Arduino Espressif32 framework.