### PR TITLE
HAL : change delay system

### DIFF
--- a/src/hal/buttons.cpp
+++ b/src/hal/buttons.cpp
@@ -36,13 +36,14 @@ void OswHal::setupButtons(void) {
 
 #if defined(GPS_EDITION) || defined(GPS_EDITION_ROTATED)
 
-void OswHal::vibrate(long millis) {
+void OswHal::vibrate(long delay) {
   digitalWrite(VIBRATE, HIGH);
 #ifndef NDEBUG
   Serial.print("Vibrate for: ");
-  Serial.println(millis);
+  Serial.println(delay);
 #endif
-  delay(millis);
+  long prev = millis();
+  while (millis() - prev <= delay);
   digitalWrite(VIBRATE, LOW);
 }
 #endif


### PR DESCRIPTION
The existing delay means a stop state, which is fatal in many ways to the board, so it implements the delay in a different way.