### PR TITLE
Apps/watchfaces : fix #213

### DIFF
--- a/src/apps/watchfaces/watchface.cpp
+++ b/src/apps/watchfaces/watchface.cpp
@@ -99,7 +99,7 @@ void OswAppWatchface::drawWatch() {
 #ifndef GIF_BG
   // seconds
   hal->gfx()->fillCircle(120, 120, 3, ui->getDangerColor());
-  hal->gfx()->drawThickTick(120, 120, 0, 16, 360.0 / 60.0 * second, 1, ui->getDangerColor());
+  hal->gfx()->drawThickTick(120, 120, 0, 16, 180 + ( 360.0 / 60.0 * second ), 1, ui->getDangerColor());
   hal->gfx()->drawThickTick(120, 120, 0, 110, 360.0 / 60.0 * second, 1, ui->getDangerColor());
 #endif
 }


### PR DESCRIPTION
Correct parameters for the short and long sides of the seconds
<img src="https://user-images.githubusercontent.com/66334969/163388390-43e2059c-69e2-4e63-a482-6864eb84a2e9.png" width="65%">
