### PR TITLE
Fix Auto sleep Timer on Watchface from Issue #186

### DIFF
--- a/src/apps/main/switcher.cpp
+++ b/src/apps/main/switcher.cpp
@@ -54,17 +54,17 @@ void OswAppSwitcher::loop() {
     }
   }
 
-  if (_enableAutoSleep && *_rtcAppIndex == 0 && !hal->btnIsDown(_btn)) {
+  if (_enableAutoSleep && *_rtcAppIndex == 0) {
+    if (hal->btnIsDown(BUTTON_1) || hal->btnIsDown(BUTTON_2) || hal->btnIsDown(BUTTON_3)) {
+    	appOnScreenSince = millis();
+    }
     short timeout = OswConfigAllKeys::settingDisplayTimeout.get();
-    if (*_rtcAppIndex == 0 && (millis() - appOnScreenSince) > timeout * 1000) {
-      if (hal->btnIsDown(BUTTON_1) || hal->btnIsDown(BUTTON_2) || hal->btnIsDown(BUTTON_3)) {
-        appOnScreenSince = millis();
-      } else if(timeout > 0) {
-        Serial.print("Going to sleep after ");
-        Serial.print(timeout);
-        Serial.println(" seconds");
-        this->sleep();
-      }
+    if (timeout > 0 && (millis() - appOnScreenSince) > timeout * 1000) {
+	Serial.print("Going to sleep after ");
+	Serial.print(timeout);
+	Serial.println(" seconds");
+	this->sleep();
+
     }
   }
 


### PR DESCRIPTION
I rewrote the auto sleep timeout so it will reset the sleep timer when any button is pressed on the main watch face, instead of only checking for button presses right before it goes to sleep.

This is my first pull request, apologies if I made it wrong.