### PR TITLE
HAL: refactoring slice-weekday

### DIFF
--- a/include/apps/watchfaces/OswAppWatchfaceDigital.h
+++ b/include/apps/watchfaces/OswAppWatchfaceDigital.h
@@ -20,6 +20,7 @@ class OswAppWatchfaceDigital : public OswApp {
     static void digitalWatch(short timeZone, uint8_t fontSize, uint8_t dateCoordY, uint8_t timeCoordY);
     static void timeOutput(uint32_t hour, uint32_t minute, uint32_t second, bool showSecond = true);
     static void dateOutput(uint32_t yearInt, uint32_t monthInt, uint32_t dayInt);
+    static void displayWeekDay3(const char *weekday);
 
   private:
     OswUI* ui;

--- a/src/apps/watchfaces/OswAppWatchfaceDigital.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceDigital.cpp
@@ -22,6 +22,17 @@ void OswAppWatchfaceDigital::refreshDateFormatCache() {
     OswAppWatchfaceDigital::dateFormatCache = (format == "mm/dd/yyyy" ? 1 : (format == "dd.mm.yyyy" ? 2 : 3));
 }
 
+// display Weekday to 3 charater
+void OswAppWatchfaceDigital::displayWeekDay3(const char *weekday) {
+    OswHal *hal = OswHal::getInstance();
+
+    char weekday3[4];
+    weekday3[0] = weekday[0];
+    weekday3[1] = weekday[1];
+    weekday3[2] = weekday[2];
+    weekday3[3] = '\0';
+    hal->gfx()->print(weekday3);
+}
 void OswAppWatchfaceDigital::dateOutput(uint32_t yearInt, uint32_t monthInt, uint32_t dayInt) {
     OswHal* hal = OswHal::getInstance();
     switch (OswAppWatchfaceDigital::getDateFormat()) {
@@ -65,14 +76,7 @@ void drawDate(short timeZone, uint8_t fontSize, uint8_t CoordY) {
     hal->gfx()->setTextLeftAligned();
     hal->gfx()->setTextCursor(120 - hal->gfx()->getTextOfsetColumns(6.9), CoordY);
 
-    {
-        char weekday3[4];
-        weekday3[0] = weekday[0];
-        weekday3[1] = weekday[1];
-        weekday3[2] = weekday[2];
-        weekday3[3] = '\0';
-        hal->gfx()->print(weekday3);
-    }
+    OswAppWatchfaceDigital::displayWeekDay3(weekday);
 
     // The GFX library has an alignment bug, causing single letters to "float", therefore the workaround above is used to still utilize the correct string printing.
     //hal->gfx()->print(weekday[0]);

--- a/src/apps/watchfaces/OswAppWatchfaceFitness.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceFitness.cpp
@@ -34,14 +34,7 @@ void dateDisplay() {
     hal->gfx()->setTextRightAligned();
     hal->gfx()->setTextCursor(205, 90);
 
-    {
-        char weekday3[4];
-        weekday3[0] = weekday[0];
-        weekday3[1] = weekday[1];
-        weekday3[2] = weekday[2];
-        weekday3[3] = '\0';
-        hal->gfx()->print(weekday3);
-    }
+    OswAppWatchfaceDigital::displayWeekDay3(weekday);
 
     // Date
     hal->gfx()->setTextSize(2);

--- a/src/apps/watchfaces/OswAppWatchfaceMix.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceMix.cpp
@@ -48,14 +48,7 @@ void OswAppWatchfaceMix::dateDisplay() {
     hal->gfx()->setTextLeftAligned();
     hal->gfx()->setTextCursor(DISP_W / 2 - OFF_SET_DATE_DIGITAL_WATCH_X_COORD, 75);
 
-    {
-        char weekday3[4];
-        weekday3[0] = weekday[0];
-        weekday3[1] = weekday[1];
-        weekday3[2] = weekday[2];
-        weekday3[3] = '\0';
-        hal->gfx()->print(weekday3);
-    }
+    OswAppWatchfaceDigital::displayWeekDay3(weekday);
 
     // The GFX library has an alignment bug, causing single letters to "float", therefore the workaround above is used to still utilize the correct string printing.
     //hal->gfx()->print(weekday[0]);


### PR DESCRIPTION
Refactoring the code below used to abbreviate the date.
```
{
  char weekday3[4];
  weekday3[0] = wd[0];
  weekday3[1] = wd[1];
  weekday3[2] = wd[2];
  weekday3[3] = '\0';
}
```