### PR TITLE
CI: omit arbitrary ci

### DIFF
--- a/.github/workflows/test-EMULATOR.yml
+++ b/.github/workflows/test-EMULATOR.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-EMULATOR:
     runs-on: ubuntu-22.04
+    if: ${{ !contains(github.event.head_commit.message, 'skip CI-emulator') }}
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v2

--- a/.github/workflows/test-FEATURE.yml
+++ b/.github/workflows/test-FEATURE.yml
@@ -30,6 +30,7 @@ jobs:
   build-OSW:
     needs: Find-feature
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'skip CI-feature') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-FEATURE.yml
+++ b/.github/workflows/test-FEATURE.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   Find-feature:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'skip CI-feature') }}
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2

--- a/.github/workflows/test-OSW.yml
+++ b/.github/workflows/test-OSW.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   Find-packages:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'skip CI-firmware') }}
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2

--- a/.github/workflows/test-OSW.yml
+++ b/.github/workflows/test-OSW.yml
@@ -24,6 +24,7 @@ jobs:
   build-OSW:
     needs: Find-packages
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'skip CI-firmware') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Commands for canceling or skipping CI in some cases.

This will reduce the time by omitting the push and making only PR work.