### PR TITLE
osw_config_keys: add stdexcept libraries

### DIFF
--- a/include/osw_config_keys.h
+++ b/include/osw_config_keys.h
@@ -5,6 +5,7 @@
 #include <WString.h>
 #include <gfx_util.h>
 
+#include <stdexcept>
 #include OSW_TARGET_PLATFORM_HEADER
 
 #include "osw_config.h"


### PR DESCRIPTION
- error: 'invalid_argument' is not a member of 'std'
```
In file included from include/osw_hal.h:17:0,
                 from include/./apps/_experiments/autumn.h:4,
                 from src/apps/_experiments/autumn.cpp:2:
include/osw_config_keys.h: In static member function 'static size_t OswConfigKeyDropDown::getOptionIndex(const std::vector<const char*>&, const String&)':
include/osw_config_keys.h:245:15: error: 'invalid_argument' is not a member of 'std'
         throw std::invalid_argument("Option not found in options list");
               ^
include/osw_config_keys.h: In member function 'void OswConfigKeyDropDown::checkValidOption(const String&)':
include/osw_config_keys.h:266:15: error: 'invalid_argument' is not a member of 'std'
         throw std::invalid_argument("Invalid option value for dropdown key!");
               ^
In file included from include/osw_hal.h:17:0,
                 from include/./apps/_experiments/dnatilt.h:4,
                 from src/apps/_experiments/dnatilt.cpp:2:
include/osw_config_keys.h: In static member function 'static size_t OswConfigKeyDropDown::getOptionIndex(const std::vector<const char*>&, const String&)':
include/osw_config_keys.h:245:15: error: 'invalid_argument' is not a member of 'std'
         throw std::invalid_argument("Option not found in options list");
               ^
include/osw_config_keys.h: In member function 'void OswConfigKeyDropDown::checkValidOption(const String&)':
include/osw_config_keys.h:266:15: error: 'invalid_argument' is not a member of 'std'
         throw std::invalid_argument("Invalid option value for dropdown key!");
```