### PR TITLE
CI: skip unnecessary actions

### DIFF
--- a/.github/workflows/test-EMULATOR.yml
+++ b/.github/workflows/test-EMULATOR.yml
@@ -14,7 +14,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@v5.2.0
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'

--- a/.github/workflows/test-EMULATOR.yml
+++ b/.github/workflows/test-EMULATOR.yml
@@ -3,14 +3,27 @@ name: OSW-EMULATOR-test
 on:
   workflow_dispatch:
   push:
+    paths_ignore: '["**/*.md", "**/scripts/screen_capture/**"]'
   pull_request:
     branches: [ master, develop ]
 
 jobs:
+  check_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+
   build-EMULATOR:
     runs-on: ubuntu-22.04
-    if: ${{ !contains(github.event.head_commit.message, 'skip CI-emulator') }}
-    steps:
+    needs: check_skip
+    if: ${{ needs.check_skip.outputs.should_skip != 'true' }}
+    steps:  
     - name: Checkout repository and submodules
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/test-FEATURE.yml
+++ b/.github/workflows/test-FEATURE.yml
@@ -14,7 +14,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@v5.2.0
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'

--- a/.github/workflows/test-FEATURE.yml
+++ b/.github/workflows/test-FEATURE.yml
@@ -3,14 +3,27 @@ name: OSW-FEATURE-test
 on:
   workflow_dispatch:
   push:
+    paths_ignore: '["*.md", "**/scripts/screen_capture/**"]'
   pull_request:
     branches: [ master, develop ]
 
 jobs:
+  check_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+
   Find-feature:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'skip CI-feature') }}
-    steps:
+    needs: check_skip
+    if: ${{ needs.check_skip.outputs.should_skip != 'true' }}
+    steps:         
       - name: Checkout repository and submodules
         uses: actions/checkout@v2
         with:
@@ -31,7 +44,6 @@ jobs:
   build-OSW:
     needs: Find-feature
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'skip CI-feature') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-OSW.yml
+++ b/.github/workflows/test-OSW.yml
@@ -3,14 +3,27 @@ name: OSW-OS-test
 on:
   workflow_dispatch:
   push:
+    paths_ignore: '["*.md", "**/scripts/screen_capture/**"]'
   pull_request:
     branches: [ master, develop ]
 
 jobs:
+  check_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+
   Find-packages:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'skip CI-firmware') }}
-    steps:
+    needs: check_skip
+    if: ${{ needs.check_skip.outputs.should_skip != 'true' }}
+    steps:      
       - name: Checkout repository and submodules
         uses: actions/checkout@v2
         with:
@@ -25,7 +38,6 @@ jobs:
   build-OSW:
     needs: Find-packages
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'skip CI-firmware') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-OSW.yml
+++ b/.github/workflows/test-OSW.yml
@@ -14,7 +14,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@v5.2.0
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'


### PR DESCRIPTION
PR for branches at the same storage level takes a lot of time to check with one push and one PR. I think we can reduce this in this way.