### PR TITLE
Added a tools screen and set the Stopwatch as the first screen of the Tools app screen

### DIFF
--- a/include/apps/tools/OswAppToolsApp.h
+++ b/include/apps/tools/OswAppToolsApp.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <osw_hal.h>
+#include <osw_ui.h>
+#include "osw_app.h"
+
+class OswAppToolsApp : public OswApp {
+  public:
+    OswAppToolsApp(void) {
+        ui = OswUI::getInstance();
+    };
+    virtual void setup() override;
+    virtual void loop() override;
+    virtual void stop() override;
+    ~OswAppToolsApp() {};
+
+  private:
+    OswUI* ui;
+};

--- a/include/apps/tools/OswAppToolsPage2App.h
+++ b/include/apps/tools/OswAppToolsPage2App.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <osw_hal.h>
+#include <osw_ui.h>
+#include "osw_app.h"
+
+class OswAppToolsPage2App : public OswApp {
+  public:
+    OswAppToolsPage2App(void) {
+        ui = OswUI::getInstance();
+    };
+    virtual void setup() override;
+    virtual void loop() override;
+    virtual void stop() override;
+    ~OswAppToolsPage2App() {};
+
+  private:
+    OswUI* ui;
+};

--- a/src/apps/tools/OswAppToolsApp.cpp
+++ b/src/apps/tools/OswAppToolsApp.cpp
@@ -1,0 +1,26 @@
+#include "./apps/tools/OswAppToolsApp.h"
+
+#include <config.h>
+#include <gfx_util.h>
+#include <osw_app.h>
+#include <osw_config.h>
+#include <osw_config_keys.h>
+#include <osw_hal.h>
+#include <osw_ui.h>
+#include <services/OswServiceTaskWebserver.h>
+#include <services/OswServiceTaskWiFi.h>
+#include <services/OswServiceTasks.h>
+
+void OswAppToolsApp::setup() {}
+
+void OswAppToolsApp::loop() {
+    OswHal* hal = OswHal::getInstance();
+    hal->gfx()->setTextSize(2);
+
+    hal->gfx()->setTextCursor(40,60);
+    hal->gfx()->print("Tools Page 1");
+
+    hal->requestFlush();
+}
+
+void OswAppToolsApp::stop() {}

--- a/src/apps/tools/OswAppToolsPage2App.cpp
+++ b/src/apps/tools/OswAppToolsPage2App.cpp
@@ -1,0 +1,26 @@
+#include "./apps/tools/OswAppToolsPage2App.h"
+
+#include <config.h>
+#include <gfx_util.h>
+#include <osw_app.h>
+#include <osw_config.h>
+#include <osw_config_keys.h>
+#include <osw_hal.h>
+#include <osw_ui.h>
+#include <services/OswServiceTaskWebserver.h>
+#include <services/OswServiceTaskWiFi.h>
+#include <services/OswServiceTasks.h>
+
+void OswAppToolsPage2App::setup() {}
+
+void OswAppToolsPage2App::loop() {
+    OswHal* hal = OswHal::getInstance();
+    hal->gfx()->setTextSize(2);
+
+     hal->gfx()->setTextCursor(40,60);
+    hal->gfx()->print("Tools Page 2");
+    
+    hal->requestFlush();
+}
+
+void OswAppToolsPage2App::stop() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,9 @@
 #ifndef NDEBUG
 #include "./apps/tools/OswAppPrintDebug.h"
 #endif
+//Tools App Screen
+#include "./apps/tools/OswAppToolsApp.h"
+#include "./apps/tools/OswAppToolsPage2App.h"
 #include "./apps/tools/OswAppTimeConfig.h"
 #include "./apps/tools/OswAppWaterLevel.h"
 #include "./apps/tools/OswAppFitnessStats.h"
@@ -73,10 +76,27 @@
 #define _MAIN_CRASH_SLEEP 2
 #endif
 
+<<<<<<< Updated upstream
 OswAppSwitcher mainAppSwitcher(BUTTON_1, LONG_PRESS, true, true, &main_currentAppIndex);
 OswAppSwitcher watchFaceSwitcher(BUTTON_1, SHORT_PRESS, false, false, &main_watchFaceIndex);
 OswAppSwitcher settingsAppSwitcher(BUTTON_1, SHORT_PRESS, false, false, &main_settingsAppIndex);
 OswAppSwitcher fitnessAppSwitcher(BUTTON_1, SHORT_PRESS, false, false, &main_fitnessAppIndex);
+=======
+OswHal* hal = nullptr;
+// OswAppRuntimeTest *runtimeTest = new OswAppRuntimeTest();
+
+uint16_t mainAppIndex = 0;              // -> wakeup from deep sleep returns to watch face (and allows auto sleep)
+RTC_DATA_ATTR uint16_t watchFaceIndex;  // Will only be initialized after deep sleep inside the setup() ↓
+uint16_t settingsAppIndex = 0;
+uint16_t fitnessAppIndex = 0;
+uint16_t ToolsAppIndex=0;
+
+OswAppSwitcher mainAppSwitcher(BUTTON_1, LONG_PRESS, true, true, &mainAppIndex);
+OswAppSwitcher watchFaceSwitcher(BUTTON_1, SHORT_PRESS, false, false, &watchFaceIndex);
+OswAppSwitcher settingsAppSwitcher(BUTTON_1, SHORT_PRESS, false, false, &settingsAppIndex);
+OswAppSwitcher fitnessAppSwitcher(BUTTON_1, SHORT_PRESS, false, false, &fitnessAppIndex);
+OswAppSwitcher ToolsAppSwitcher(BUTTON_1, SHORT_PRESS, false, false, &ToolsAppIndex);
+>>>>>>> Stashed changes
 
 void setup() {
     Serial.begin(115200);
@@ -181,7 +201,8 @@ void loop() {
         mainAppSwitcher.registerApp(&fitnessAppSwitcher);
         // tools
 #if TOOL_STOPWATCH == 1
-        mainAppSwitcher.registerApp(new OswAppStopWatch());
+        //mainAppSwitcher.registerApp(new OswAppStopWatch());
+        ToolsAppSwitcher.registerApp(new OswAppStopWatch());
 #endif
 #if TOOL_WATERLEVEL == 1
         mainAppSwitcher.registerApp(new OswAppWaterLevel());
@@ -198,6 +219,13 @@ void loop() {
 #endif
         settingsAppSwitcher.paginationEnable();
         mainAppSwitcher.registerApp(&settingsAppSwitcher);
+
+        // new tools screen
+        ToolsAppSwitcher.registerApp(new OswAppToolsApp());
+        ToolsAppSwitcher.registerApp(new OswAppToolsPage2App());
+        ToolsAppSwitcher.paginationEnable();
+        mainAppSwitcher.registerApp(&ToolsAppSwitcher);
+
 
         // games
 #if GAME_SNAKE == 1


### PR DESCRIPTION
This is another example of the Tools Screen. Currently contains the stopwatch as the first screen and two template screens after that called "Page 1" and "Page 2", which can be modified or replaced. ( the plan is to replace them in the near future ). Another option would be to move the "Water Level" and the "Stop Watch" into this Tools Screen instead of having them separate on the main app switcher. This  could easily be done.