### PR TITLE
Simplifies API usage

### DIFF
--- a/include/osw_hal.h
+++ b/include/osw_hal.h
@@ -28,6 +28,21 @@
 #define ERR_SD_MISSING 1
 #define ERR_SD_MOUNT_FAILED 2
 
+typedef struct {
+    uint32_t hour;
+    uint32_t minute;
+    uint32_t second;
+    bool afterNoon;
+} OSW_TIME;
+
+typedef struct {
+    uint32_t year;
+    uint32_t month;
+    uint32_t day;
+    uint32_t weekDay;
+    const char* weekDayName;
+} OSW_DATE;
+
 class OswHal {
   public:
     static OswHal* getInstance();
@@ -181,7 +196,7 @@ class OswHal {
     // UTC Time
     void setUTCTime(const time_t& epoch);
     time_t getUTCTime();
-    void getUTCTime(uint32_t* hour, uint32_t* minute, uint32_t* second);
+    void getUTCTime(OSW_TIME* oswTime);
 
     // Offset getters for primary / secondary time (cached!)
     time_t getTimezoneOffsetPrimary();
@@ -189,43 +204,29 @@ class OswHal {
 
     // New time functions with offset
     time_t getTime(time_t& offset);
-    void getTime(time_t& offset, uint32_t* hour, uint32_t* minute, uint32_t* second, bool* afterNoon = nullptr);
-    void getDate(time_t& offset, uint32_t* day, uint32_t* weekDay);
-    void getDate(time_t& offset, uint32_t* day, uint32_t* month, uint32_t* year);
-    const char* getWeekday(time_t& offset, uint32_t* setWDay = nullptr);
+    void getTime(time_t& offset, OSW_TIME* oswTime);
+    void getDate(time_t& offset, OSW_DATE* oswDate, uint32_t* setWDay = nullptr);
 
     // For backward compatibility: Local time functions (= primary timezone)
-    inline void getLocalTime(uint32_t* hour, uint32_t* minute, uint32_t* second, bool* afterNoon = nullptr) {
-        this->getTime(this->timezoneOffsetPrimary, hour, minute, second, afterNoon);
+    inline void getLocalTime(OSW_TIME* oswTime) {
+        this->getTime(this->timezoneOffsetPrimary, oswTime);
     }
     inline uint32_t getLocalTime() {
         return this->getTime(this->timezoneOffsetPrimary);
     }
-    inline void getLocalDate(uint32_t* day, uint32_t* weekDay) {
-        this->getDate(this->timezoneOffsetPrimary, day, weekDay);
-    };
-    inline void getLocalDate(uint32_t* day, uint32_t* month, uint32_t* year) {
-        this->getDate(this->timezoneOffsetPrimary, day, month, year);
-    };
-    inline const char* getLocalWeekday(uint32_t* sWDay = nullptr) {
-        return this->getWeekday(this->timezoneOffsetPrimary, sWDay);
+    inline void getLocalDate(OSW_DATE* oswDate, uint32_t* sWDay = nullptr) {
+        this->getDate(this->timezoneOffsetPrimary, oswDate, sWDay);
     };
 
     // For backward compatibility: Dual time functions (= secondary timezone)
-    inline void getDualTime(uint32_t* hour, uint32_t* minute, uint32_t* second, bool* afterNoon = nullptr) {
-        this->getTime(this->timezoneOffsetSecondary, hour, minute, second, afterNoon);
+    inline void getDualTime(OSW_TIME* oswTime) {
+        this->getTime(this->timezoneOffsetSecondary, oswTime);
     }
     inline uint32_t getDualTime() {
         return this->getTime(this->timezoneOffsetSecondary);
     }
-    inline void getDualDate(uint32_t* day, uint32_t* weekDay) {
-        this->getDate(this->timezoneOffsetSecondary, day, weekDay);
-    };
-    inline void getDualDate(uint32_t* day, uint32_t* month, uint32_t* year) {
-        this->getDate(this->timezoneOffsetSecondary, day, month, year);
-    };
-    inline const char* getDualWeekday(uint32_t* sWDay = nullptr) {
-        return this->getWeekday(this->timezoneOffsetSecondary, sWDay);
+    inline void getDualDate(OSW_DATE* oswDate, uint32_t* sWDay = nullptr) {
+        this->getDate(this->timezoneOffsetPrimary, oswDate, sWDay);
     };
 
     bool _requestDisableBuffer = false;

--- a/src/apps/tools/OswAppDistStats.cpp
+++ b/src/apps/tools/OswAppDistStats.cpp
@@ -15,9 +15,10 @@ void OswAppDistStats::drawChart() {
     uint8_t interval = 20;
     uint16_t goalValue = OswConfigAllKeys::distPerDay.get();
 
-    uint32_t weekDay = 0;
-    uint32_t dayOfMonth = 0;
-    hal->getLocalDate(&dayOfMonth, &weekDay);
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    uint32_t weekDay = oswDate.day;
+    uint32_t dayOfMonth = oswDate.weekDay;
 
     for (uint8_t index = 0; index < 7; index++) {
         uint32_t weekDayDist = OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsOnDay(index));
@@ -46,15 +47,14 @@ void OswAppDistStats::showStickChart() {
     hal->gfx()->print(LANG_DISTSTATS_TITLE);
 
     OswAppDistStats::drawChart();
-    OswAppStepStats::drawInfoPanel(ui, (uint32_t)cursorPos, OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsOnDay((uint32_t)cursorPos, true)), OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsOnDay((uint32_t)cursorPos)), OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsAverage()), OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsTotalWeek()), " m");
+    OswAppStepStats::drawInfoPanel(ui, cursorPos, OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsOnDay((uint32_t)cursorPos, true)), OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsOnDay((uint32_t)cursorPos)), OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsAverage()), OswAppWatchfaceFitness::calculateDistance(hal->environment()->getStepsTotalWeek()), " m");
 }
 
 void OswAppDistStats::setup() {
     OswHal* hal = OswHal::getInstance();
-    uint32_t weekDay = 0;
-    uint32_t dayOfMonth = 0;
-    hal->getLocalDate(&dayOfMonth, &weekDay);
-    cursorPos = weekDay;
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    cursorPos = oswDate.weekDay;
 }
 void OswAppDistStats::loop() {
     OswHal* hal = OswHal::getInstance();

--- a/src/apps/tools/OswAppKcalStats.cpp
+++ b/src/apps/tools/OswAppKcalStats.cpp
@@ -14,9 +14,9 @@
 
 uint32_t findCursorWeekDay(uint8_t Index) {  // Show the day of the week that cursor (Dynamic weekDay--info)
     OswHal* hal = OswHal::getInstance();
-    uint32_t d, wD = 0;
-    hal->getLocalDate(&d, &wD);
-    int cursorWeekDay = wD - (6 - Index);
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    int cursorWeekDay = oswDate.weekDay - (6 - Index);
     int findWeekDay = (cursorWeekDay >= 0) ? cursorWeekDay : (cursorWeekDay + 7);
     uint32_t fWD = findWeekDay;
     return fWD;

--- a/src/apps/tools/OswAppStepStats.cpp
+++ b/src/apps/tools/OswAppStepStats.cpp
@@ -14,9 +14,10 @@ void OswAppStepStats::drawChart() {
     uint8_t interval = 20;
     uint16_t goalValue = OswConfigAllKeys::stepsPerDay.get();
 
-    uint32_t weekDay = 0;
-    uint32_t dayOfMonth = 0;
-    hal->getLocalDate(&dayOfMonth, &weekDay);
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    uint32_t weekDay = oswDate.weekDay;
+    uint32_t dayOfMonth = oswDate.day;
 
     for (uint8_t index = 0; index < 7; index++) {
         unsigned int weekDayStep = hal->environment()->getStepsOnDay(index);
@@ -43,7 +44,10 @@ void OswAppStepStats::drawInfoPanel(OswUI* ui, uint32_t pos, uint32_t lastWeekDa
     hal->gfx()->setTextCenterAligned();
     hal->gfx()->setTextBottomAligned();
     hal->gfx()->setTextCursor(DISP_W / 2, 170);
-    hal->gfx()->print(hal->getLocalWeekday(&pos));
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate, &pos);
+    const char* weekday = oswDate.weekDayName;
+    hal->gfx()->print(weekday);
     hal->gfx()->setTextCursor(DISP_W / 2, 190);
     hal->gfx()->print(String(lastWeekData)); // lastweek(before 7 day)
     hal->gfx()->setTextCursor(DISP_W / 2, 215);
@@ -69,10 +73,9 @@ void OswAppStepStats::showStickChart() {
 
 void OswAppStepStats::setup() {
     OswHal* hal = OswHal::getInstance();
-    uint32_t weekDay = 0;
-    uint32_t dayOfMonth = 0;
-    hal->getLocalDate(&dayOfMonth, &weekDay);
-    cursorPos = weekDay;
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    cursorPos = oswDate.weekDay;
 }
 void OswAppStepStats::loop() {
     OswHal* hal = OswHal::getInstance();

--- a/src/apps/tools/OswAppTimeConfig.cpp
+++ b/src/apps/tools/OswAppTimeConfig.cpp
@@ -15,14 +15,16 @@
 void OswAppTimeConfig::setup() {}
 
 void OswAppTimeConfig::enterManualMode() {
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    uint32_t day = 0;
-    uint32_t month = 0;
-    uint32_t year = 0;
-    OswHal::getInstance()->getLocalTime(&hour, &minute, &second);
-    OswHal::getInstance()->getLocalDate(&day, &month, &year);
+    OSW_TIME oswTime = { 0, };
+    OSW_DATE oswDate = { 0, };
+    OswHal::getInstance()->getLocalTime(&oswTime);
+    OswHal::getInstance()->getLocalDate(&oswDate);
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
+    uint32_t day = oswDate.day;
+    uint32_t month = oswDate.month;
+    uint32_t year = oswDate.year;
     manualSettingTimestamp[0] = year % 10;
     manualSettingTimestamp[1] = month / 10;
     manualSettingTimestamp[2] = month % 10;
@@ -196,16 +198,13 @@ void OswAppTimeConfig::loop() {
         hal->gfx()->setTextMiddleAligned();
         hal->gfx()->setTextLeftAligned();
         hal->gfx()->setTextCursor(120 - hal->gfx()->getTextOfsetColumns(4), 120);
-
-        uint32_t second = 0;
-        uint32_t minute = 0;
-        uint32_t hour = 0;
-        hal->getLocalTime(&hour, &minute, &second);
-        hal->gfx()->printDecimal(hour, 2);
+        OSW_TIME oswTime = { 0, };
+        hal->getLocalTime(&oswTime);
+        hal->gfx()->printDecimal(oswTime.hour, 2);
         hal->gfx()->print(":");
-        hal->gfx()->printDecimal(minute, 2);
+        hal->gfx()->printDecimal(oswTime.minute, 2);
         hal->gfx()->print(":");
-        hal->gfx()->printDecimal(second, 2);
+        hal->gfx()->printDecimal(oswTime.second, 2);
 
     } else {
         handleIncrementButton();

--- a/src/apps/watchfaces/OswAppWatchface.cpp
+++ b/src/apps/watchfaces/OswAppWatchface.cpp
@@ -28,9 +28,11 @@ const char* OswAppWatchface::getAppName() {
 void OswAppWatchface::drawStepHistory(OswUI* ui, uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint32_t max) {
     OswHal* hal = OswHal::getInstance();
     OswUI::getInstance()->resetTextColors();
-    uint32_t weekDay = 0;
-    uint32_t dayOfMonth = 0;
-    hal->getLocalDate(&dayOfMonth, &weekDay);
+
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    uint32_t weekDay = oswDate.weekDay;
+
     for (uint8_t i = 0; i < 7; i++) {
         uint32_t s = hal->environment()->getStepsOnDay(i);
         uint16_t boxHeight = ((float)(s > max ? max : s) / max) * h;
@@ -64,6 +66,7 @@ void OswAppWatchface::drawStepHistory(OswUI* ui, uint8_t x, uint8_t y, uint8_t w
 void OswAppWatchface::drawWatch() {
     OswHal* hal = OswHal::getInstance();
 
+
     hal->gfx()->drawMinuteTicks(CENTER_Y, CENTER_Y, 116, 112, ui->getForegroundDimmedColor(), true);
     hal->gfx()->drawHourTicks(CENTER_X, CENTER_Y, 117, 107, ui->getForegroundColor(), true);
 
@@ -91,16 +94,18 @@ void OswAppWatchface::drawWatch() {
     // hal->gfx()->drawArc(120, 120, 0, bat, 180, 57, 7, dimColor(COLOR_BLUE, 25));
     // hal->gfx()->drawArc(120, 120, 0, bat, 180, 57, 6, COLOR_BLUE);
 
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    hal->getLocalTime(&hour, &minute, &second);
+    OSW_TIME oswTime = { 0, };
+    hal->getLocalTime(&oswTime);
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
 
     if(OswConfigAllKeys::settingDisplayDualHourTick.get()) {
-        uint32_t dualSecond = 0;
-        uint32_t dualMinute = 0;
-        uint32_t dualHour = 0;
-        hal->getDualTime(&dualHour, &dualMinute, &dualSecond);
+        OSW_TIME oswTime = { 0, };
+        hal->getDualTime(&oswTime);
+        uint32_t dualSecond = oswTime.second;
+        uint32_t dualMinute = oswTime.minute;
+        uint32_t dualHour = oswTime.hour;
 
         // dual-hours
         hal->gfx()->drawThickTick(CENTER_X, CENTER_Y, 0, 16, (int)(360.0f / 12.0f * (dualHour + dualMinute / 60.0f)), 2, ui->getBackgroundDimmedColor(), true, STRAIGHT_END);

--- a/src/apps/watchfaces/OswAppWatchfaceBinary.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceBinary.cpp
@@ -14,12 +14,14 @@
 #define COLOR_WHxITE rgb565(255, 255, 255)
 
 void OswAppWatchfaceBinary::drawWatch() {
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    bool afterNoon = false;
     OswHal* hal = OswHal::getInstance();
-    hal->getLocalTime(&hour, &minute, &second, &afterNoon);
+    
+    OSW_TIME oswTime = { 0, };
+    hal->getLocalTime(&oswTime);
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
+    bool afterNoon = oswTime.afterNoon;
 
     uint16_t width = hal->gfx()->getWidth();
     uint16_t height = hal->gfx()->getHeight();

--- a/src/apps/watchfaces/OswAppWatchfaceDigital.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceDigital.cpp
@@ -64,11 +64,16 @@ static void drawDate(time_t timeZone, uint8_t fontSize, uint8_t CoordY) {
     uint32_t dayInt = 0;
     uint32_t monthInt = 0;
     uint32_t yearInt = 0;
+    const char* weekday = nullptr;
+    OSW_DATE oswDate = { 0, };
     OswHal* hal = OswHal::getInstance();
-    const char* weekday = hal->getWeekday(timeZone);
 
-    hal->getDate(timeZone,&dayInt, &monthInt, &yearInt);
+    hal->getDate(timeZone, &oswDate);
 
+    dayInt = oswDate.day;
+    monthInt = oswDate.month;
+    yearInt = oswDate.year;
+    weekday = oswDate.weekDayName;
     // we want to output a value like "Wed, 05/02/2021"
 
     hal->gfx()->setTextSize(fontSize);
@@ -101,10 +106,7 @@ void OswAppWatchfaceDigital::timeOutput(uint32_t hour, uint32_t minute, uint32_t
 }
 
 static void drawTime(time_t timeZone,uint8_t CoordY) {
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    bool afterNoon = false;
+    OSW_TIME oswTime = { 0, };
     char am[] = "AM";
     char pm[] = "PM";
     OswHal* hal = OswHal::getInstance();
@@ -114,11 +116,11 @@ static void drawTime(time_t timeZone,uint8_t CoordY) {
     hal->gfx()->setTextLeftAligned();
     hal->gfx()->setTextCursor(120 - hal->gfx()->getTextOfsetColumns(OswConfigAllKeys::timeFormat.get() ? 4 : 5.5),CoordY );
 
-    hal->getTime(timeZone,&hour, &minute, &second, &afterNoon);
-    OswAppWatchfaceDigital::timeOutput(hour, minute, second);
+    hal->getTime(timeZone, &oswTime);
+    OswAppWatchfaceDigital::timeOutput(oswTime.hour, oswTime.minute, oswTime.second);
     if (!OswConfigAllKeys::timeFormat.get()) {
         hal->gfx()->print(" ");
-        if (afterNoon) {
+        if (oswTime.afterNoon) {
             hal->gfx()->print(pm);
         } else {
             hal->gfx()->print(am);

--- a/src/apps/watchfaces/OswAppWatchfaceDual.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceDual.cpp
@@ -32,9 +32,9 @@ void OswAppWatchfaceDual::drawProgressBar(OswUI* ui,uint8_t cx, uint8_t cy, uint
 void OswAppWatchfaceDual::drawAnimSec() {
     OswHal* hal = OswHal::getInstance();
     uint8_t barWidth = 140;
-    uint32_t Hs, Ms, Ss = 0;
-    hal->getLocalTime(&Hs,&Ms,&Ss);
-    uint32_t onlySecond = Ss;
+    OSW_TIME oswTime = { 0, };
+    hal->getLocalTime(&oswTime);
+    uint32_t onlySecond = oswTime.second;
     uint16_t barValue = ((float)onlySecond / 60) * barWidth;
     barValue = barValue < 2 ? 0 : barValue;
     uint8_t coordX = (DISP_W - barWidth) / 2;

--- a/src/apps/watchfaces/OswAppWatchfaceFitness.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceFitness.cpp
@@ -25,14 +25,15 @@ uint32_t OswAppWatchfaceFitness::calculateKcalorie(uint32_t steps) {
 }
 
 void dateDisplay() {
-    uint32_t dayInt = 0;
-    uint32_t monthInt = 0;
-    uint32_t yearInt = 0;
     OswHal* hal = OswHal::getInstance();
-    const char* weekday = hal->getLocalWeekday();
 
-    hal->getLocalDate(&dayInt, &monthInt, &yearInt);
-
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    uint32_t dayInt = oswDate.day;
+    uint32_t monthInt = oswDate.month;
+    uint32_t yearInt = oswDate.year;
+    const char* weekday = oswDate.weekDayName;
+    
     hal->gfx()->setTextSize(2);
     hal->gfx()->setTextMiddleAligned();
     hal->gfx()->setTextRightAligned();
@@ -62,10 +63,6 @@ void timeDisplay(uint32_t hour, uint32_t minute, uint32_t second) {
 }
 
 void digitalWatchDisplay() {
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    bool afterNoon = false;
     char am[] = "AM";
     char pm[] = "PM";
     OswHal* hal = OswHal::getInstance();
@@ -74,8 +71,12 @@ void digitalWatchDisplay() {
     hal->gfx()->setTextMiddleAligned();
     hal->gfx()->setTextLeftAligned();
     hal->gfx()->setTextCursor(DISP_W / 2 - 30, DISP_W / 2);
-
-    hal->getLocalTime(&hour, &minute, &second, &afterNoon);
+    OSW_TIME oswTime = { 0, };
+    hal->getLocalTime(&oswTime);
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
+    bool afterNoon = oswTime.afterNoon;
 
     timeDisplay(hour, minute, second);
     if (!OswConfigAllKeys::timeFormat.get()) {

--- a/src/apps/watchfaces/OswAppWatchfaceFitnessAnalog.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceFitnessAnalog.cpp
@@ -111,7 +111,9 @@ void OswAppWatchfaceFitnessAnalog::drawWatchFace(OswHal* hal, uint32_t hour, uin
 }
 
 void OswAppWatchfaceFitnessAnalog::drawDateFace(OswHal* hal, uint32_t hour, uint32_t minute, uint32_t second, bool afterNoon) {
-    const char* weekday = hal->getLocalWeekday();
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    const char* weekday = oswDate.weekDayName;
 
     hal->gfx()->setTextSize(2);
     hal->gfx()->setTextRightAligned();
@@ -119,10 +121,10 @@ void OswAppWatchfaceFitnessAnalog::drawDateFace(OswHal* hal, uint32_t hour, uint
     OswAppWatchfaceDigital::displayWeekDay3(weekday);
 
     // Date
-    uint32_t dayInt = 0;
-    uint32_t monthInt = 0;
-    uint32_t yearInt = 0;
-    hal->getLocalDate(&dayInt, &monthInt, &yearInt);
+    uint32_t dayInt = oswDate.day;
+    uint32_t monthInt = oswDate.month;
+    uint32_t yearInt = oswDate.year;
+    
     hal->gfx()->setTextSize(3);
     hal->gfx()->setTextLeftAligned();
     hal->gfx()->setTextCursor(CENTER_X - 70, 170);
@@ -207,11 +209,11 @@ void OswAppWatchfaceFitnessAnalog::onDraw() {
 
     OswHal* hal = OswHal::getInstance();
 
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    bool afterNoon;
-    hal->getLocalTime(&hour, &minute, &second, &afterNoon);
+    OSW_TIME oswTime = { 0, };
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
+    bool afterNoon = oswTime.afterNoon;
 
     if (this->screen == 0) {
 #if OSW_PLATFORM_ENVIRONMENT_ACCELEROMETER == 1

--- a/src/apps/watchfaces/OswAppWatchfaceMix.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceMix.cpp
@@ -23,11 +23,12 @@ const char* OswAppWatchfaceMix::getAppName() {
 
 void OswAppWatchfaceMix::analogWatchDisplay() {
     OswHal* hal = OswHal::getInstance();
-    uint32_t second = 0;
-    uint32_t minute = 0;  // Unused, but required by function signature
-    uint32_t hour = 0;    // Unused, but required by function signature
+    OSW_TIME oswTime = { 0, };
+    hal->getLocalTime(&oswTime);
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
 
-    hal->getLocalTime(&hour, &minute, &second);
     hal->gfx()->drawCircle((int)(DISP_W*0.5)-OFF_SET_ANALOG_WATCH_X_COORD, 100, 50, ui->getForegroundColor());
     hal->gfx()->drawHourTicks((int)(DISP_W*0.5)-OFF_SET_ANALOG_WATCH_X_COORD, 100, 45, 40, ui->getForegroundDimmedColor());
 
@@ -49,13 +50,14 @@ void OswAppWatchfaceMix::analogWatchDisplay() {
 }
 
 void OswAppWatchfaceMix::dateDisplay() {
-    uint32_t dayInt = 0;
-    uint32_t monthInt = 0;
-    uint32_t yearInt = 0;
     OswHal* hal = OswHal::getInstance();
-    const char* weekday = hal->getLocalWeekday();
 
-    hal->getLocalDate(&dayInt, &monthInt, &yearInt);
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    uint32_t dayInt = oswDate.day;
+    uint32_t monthInt = oswDate.month;
+    uint32_t yearInt = oswDate.year;
+    const char* weekday = oswDate.weekDayName;
 
     hal->gfx()->setTextSize(1);
     hal->gfx()->setTextMiddleAligned();
@@ -76,10 +78,6 @@ void OswAppWatchfaceMix::dateDisplay() {
 }
 
 void OswAppWatchfaceMix::digitalWatchDisplay() {
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    bool afterNoon = false;
     char am[] = "AM";
     char pm[] = "PM";
     OswHal* hal = OswHal::getInstance();
@@ -89,7 +87,12 @@ void OswAppWatchfaceMix::digitalWatchDisplay() {
     hal->gfx()->setTextLeftAligned();
     hal->gfx()->setTextCursor(DISP_W / 2 - OFF_SET_DATE_DIGITAL_WATCH_X_COORD, DISP_H / 2);
 
-    hal->getLocalTime(&hour, &minute, &second, &afterNoon);
+    OSW_TIME oswTime = { 0, };
+    hal->getLocalTime(&oswTime);
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
+    bool afterNoon = oswTime.afterNoon;
     OswAppWatchfaceDigital::timeOutput(hour, minute, second,false);
     if (!OswConfigAllKeys::timeFormat.get()) {
         hal->gfx()->setTextSize(1);

--- a/src/apps/watchfaces/OswAppWatchfaceMonotimer.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceMonotimer.cpp
@@ -104,16 +104,18 @@ void OswAppWatchfaceMonotimer::drawWatch() {
 #endif
 
     // ticks
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    hal->getLocalTime(&hour, &minute, &second);
+    OSW_TIME oswTime = { 0, };
+    hal->getLocalTime(&oswTime);
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
 
     if (OswConfigAllKeys::settingDisplayDualHourTick.get()) {
-        uint32_t dualSecond = 0;
-        uint32_t dualMinute = 0;
-        uint32_t dualHour = 0;
-        hal->getDualTime(&dualHour, &dualMinute, &dualSecond);
+        OSW_TIME oswTime = { 0, };
+        hal->getDualTime(&oswTime);
+        uint32_t dualSecond = oswTime.second;
+        uint32_t dualMinute = oswTime.minute;
+        uint32_t dualHour = oswTime.hour;
 
         hal->gfx()->drawThickTick(120, 120, 0, 105, (360.0f * (60 * dualHour + dualMinute)) / 720.0f, 1, ui->getBackgroundDimmedColor());
     }

--- a/src/apps/watchfaces/OswAppWatchfaceNumerals.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceNumerals.cpp
@@ -33,17 +33,19 @@ void OswAppWatchfaceNumerals::drawWatch() {
 
     OswAppWatchfaceMonotimer::drawHour();
 
-    uint32_t dayInt = 0;
-    uint32_t monthInt = 0;
-    uint32_t yearInt = 0;
-    hal->getLocalDate(&dayInt, &monthInt, &yearInt);
+    OSW_DATE oswDate = { 0, };
+    hal->getLocalDate(&oswDate);
+    uint32_t dayInt = oswDate.day;
+    uint32_t monthInt = oswDate.month;
+    uint32_t yearInt = oswDate.year;
+    
     hal->gfx()->setTextCenterAligned();
     hal->gfx()->setTextSize(1);
     hal->gfx()->setTextColor(ui->getDangerColor());
     hal->gfx()->setTextCursor(120, 85);
     hal->gfx()->print(dayInt);
 
-    const char* weekday = hal->getLocalWeekday();
+    const char* weekday = oswDate.weekDayName;
     hal->gfx()->setTextCursor(120, 70);
     OswAppWatchfaceDigital::displayWeekDay3(weekday);
 
@@ -61,15 +63,17 @@ void OswAppWatchfaceNumerals::drawWatch() {
 #endif
 
     // ticks
-    uint32_t second = 0;
-    uint32_t minute = 0;
-    uint32_t hour = 0;
-    hal->getLocalTime(&hour, &minute, &second);
+    OSW_TIME oswTime = { 0, };
+    hal->getLocalTime(&oswTime);
+    uint32_t second = oswTime.second;
+    uint32_t minute = oswTime.minute;
+    uint32_t hour = oswTime.hour;
     if(OswConfigAllKeys::settingDisplayDualHourTick.get()) {
-        uint32_t dualSecond = 0;
-        uint32_t dualMinute = 0;
-        uint32_t dualHour = 0;
-        hal->getDualTime(&dualHour, &dualMinute, &dualSecond);
+        OSW_TIME oswTime = { 0, };
+        hal->getDualTime(&oswTime);
+        uint32_t dualSecond = oswTime.second;
+        uint32_t dualMinute = oswTime.minute;
+        uint32_t dualHour = oswTime.hour;
 
         // dual-hours
         hal->gfx()->drawThickTick(DISP_W / 2, DISP_H / 2, 0, 16, 360.0f / 12.0f * (dualHour + dualMinute / 60.0f), 2, ui->getBackgroundDimmedColor());

--- a/src/hal/environment.cpp
+++ b/src/hal/environment.cpp
@@ -132,9 +132,9 @@ void OswHal::Environment::setupStepStatistics() {
  * @param alwaysPrintStepStatistics Set to true to print the step history to the console
  */
 void OswHal::Environment::commitStepStatistics(const bool& alwaysPrintStepStatistics) {
-    uint32_t currDoM = 0; // Unused, but required by function signature
-    uint32_t currDoW = 0;
-    OswHal::getInstance()->getLocalDate(&currDoM, &currDoW);
+    OSW_DATE oswDate = { 0, };
+    OswHal::getInstance()->getLocalDate(&oswDate);
+    uint32_t currDoW = oswDate.weekDay;
     bool changedDoW = currDoW != this->_stepsLastDoW;
     if(changedDoW) {
         Preferences prefs;
@@ -196,10 +196,9 @@ void OswHal::Environment::commitStepStatistics(const bool& alwaysPrintStepStatis
 
 uint32_t OswHal::Environment::getStepsOnDay(uint8_t dayOfWeek, bool lastWeek) {
     this->commitStepStatistics();
-    uint32_t day = 0;
-    uint32_t weekday = 0;
-    OswHal::getInstance()->getLocalDate(&day, &weekday);
-
+    OSW_DATE oswDate = { 0, };
+    OswHal::getInstance()->getLocalDate(&oswDate);
+    uint32_t weekday = oswDate.weekDay;
     if (!lastWeek and dayOfWeek == weekday)
         return this->getStepsToday();
     else if(!lastWeek or (lastWeek and dayOfWeek == weekday))
@@ -225,9 +224,9 @@ uint32_t OswHal::Environment::getStepsTotalWeek() {
 #ifdef OSW_FEATURE_STATS_STEPS
     this->commitStepStatistics();
     uint32_t sum = 0;
-    uint32_t currDoM = 0;  // Unused, but required by function signature
-    uint32_t currDoW = 0;
-    OswHal::getInstance()->getLocalDate(&currDoM, &currDoW);
+    OSW_DATE oswDate = { 0, };
+    OswHal::getInstance()->getLocalDate(&oswDate);
+    uint32_t currDoW = oswDate.weekDay;
     for (uint8_t i = 0; i < 7; i++) {
         if (i == currDoW) {
             sum = sum + this->getStepsToday();

--- a/src/hal/time.cpp
+++ b/src/hal/time.cpp
@@ -26,37 +26,37 @@ void OswHal::updateTimeProvider() {
         OSW_LOG_D("No provider for Time is available!");
 }
 
-void OswHal::getUTCTime(uint32_t* hour, uint32_t* minute, uint32_t* second) {
+void OswHal::getUTCTime(OSW_TIME* oswTime) {
     RtcDateTime d = RtcDateTime();
     d.InitWithUnix32Time(this->getUTCTime());
-    *hour = d.Hour();
-    *minute = d.Minute();
-    *second = d.Second();
+    oswTime->hour = d.Hour();
+    oswTime->minute = d.Minute();
+    oswTime->second = d.Second();
 }
 
-void OswHal::getTime(time_t& offset, uint32_t* hour, uint32_t* minute, uint32_t* second, bool* afterNoon) {
+void OswHal::getTime(time_t& offset, OSW_TIME* oswTime) {
     RtcDateTime d = RtcDateTime();
     d.InitWithUnix32Time(this->getTime(offset));
     if (!OswConfigAllKeys::timeFormat.get()) {
         if (d.Hour() > 12) {
-            *hour = d.Hour() - 12;
-            if (afterNoon != nullptr) *afterNoon = true;
+            oswTime->hour = d.Hour() - 12;
+            oswTime->afterNoon = true;
         } else if (d.Hour() == 0) {
-            *hour = 12;
-            if (afterNoon != nullptr) *afterNoon = false;
+            oswTime->hour = 12;
+            oswTime->afterNoon = false;
         } else if (d.Hour() == 12) {
-            *hour = d.Hour();
-            if (afterNoon != nullptr) *afterNoon = true;
+            oswTime->hour = d.Hour();
+            oswTime->afterNoon = true;
         } else {
-            *hour = d.Hour();
-            if (afterNoon != nullptr) *afterNoon = false;
+            oswTime->hour = d.Hour();
+            oswTime->afterNoon = false;
         }
     } else {
-        *hour = d.Hour();
-        if (afterNoon != nullptr) *afterNoon = false;
+        oswTime->hour = d.Hour();
+        oswTime->afterNoon = false;
     }
-    *minute = d.Minute();
-    *second = d.Second();
+    oswTime->minute = d.Minute();
+    oswTime->second = d.Second();
 }
 
 /**
@@ -122,27 +122,26 @@ time_t OswHal::getTime(time_t& offset) {
     return this->getUTCTime() + offset;
 }
 
-void OswHal::getDate(time_t& offset, uint32_t* day, uint32_t* weekDay) {
+void OswHal::getDate(time_t& offset, OSW_DATE* oswDate, uint32_t* setWDay) {
+    const char* dayMap[7] = {
+        LANG_SUNDAY
+        , LANG_MONDAY
+        , LANG_TUESDAY
+        , LANG_WEDNESDAY
+        , LANG_THURSDAY
+        , LANG_FRIDAY
+        , LANG_SATURDAY
+    };
+
     RtcDateTime d = RtcDateTime();
     d.InitWithUnix32Time(this->getTime(offset));
-    *weekDay = d.DayOfWeek();
-    *day = d.Day();
-}
-
-void OswHal::getDate(time_t& offset, uint32_t* day, uint32_t* month, uint32_t* year) {
-    RtcDateTime d = RtcDateTime();
-    d.InitWithUnix32Time(this->getTime(offset));
-    *day = d.Day();
-    *month = d.Month();
-    *year = d.Year();
-}
-
-const char* OswHal::getWeekday(time_t& offset, uint32_t* setWDay) {
-    uint32_t day = 0;
-    uint32_t wDay = 0;
-    this->getDate(offset, &day, &wDay);
-
-    const char* dayMap[7] = {LANG_SUNDAY, LANG_MONDAY, LANG_TUESDAY, LANG_WEDNESDAY, LANG_THURSDAY, LANG_FRIDAY, LANG_SATURDAY};
-    if (setWDay != nullptr) wDay = *setWDay;
-    return dayMap[wDay];
+    oswDate->year = d.Year();
+    oswDate->month = d.Month();
+    oswDate->day = d.Day();
+    oswDate->weekDay = d.DayOfWeek();
+    if (setWDay != nullptr) {
+        oswDate->weekDayName = dayMap[*setWDay];
+    } else {
+        oswDate->weekDayName = dayMap[oswDate->weekDay];
+    }
 }


### PR DESCRIPTION
Update getDate, getTime API

How to use
```
OSW_TIME oswTime = { 0, };
hal->getLocalTime(&oswTime);
```
Each element can be referred to as a sub-element. It returns data for a time or date and can be used by selecting the necessary elements.