### PR TITLE
Fix for #404

### DIFF
--- a/emulator/src/Emulator.cpp
+++ b/emulator/src/Emulator.cpp
@@ -12,6 +12,7 @@
 #include "../include/Display.h"
 #include "../include/Emulator.hpp"
 
+#include "globals.h"
 #include "osw_ui.h"
 #include "osw_config.h"
 #include "osw_config_keys.h"
@@ -318,6 +319,7 @@ void OswEmulator::doCleanup() {
     OswUI::resetInstance();
     OswHal::resetInstance();
     OswLogger::resetInstance();
+    OswGlobals::resetGlobals();
     this->cpustate = CPUState::deep;
     this->wantCleanup = false;
 }

--- a/include/apps/OswAppDrawer.h
+++ b/include/apps/OswAppDrawer.h
@@ -39,6 +39,9 @@ class OswAppDrawer: public OswAppV2 {
         this->apps.at(category).emplace_back(nullptr);
         this->apps.at(category).back().set<T>();
     };
+#ifdef OSW_EMULATOR
+    void reset();
+#endif
 
     // Control functions, those will schedule their action for the next loop() of the drawer (preventing e.g. undefined behavior of switching apps while drawing)
     void showDrawer();

--- a/include/globals.h
+++ b/include/globals.h
@@ -24,4 +24,9 @@ namespace OswGlobals {
 RTC_DATA_ATTR extern size_t main_AppIndex;
 extern OswAppDrawer main_mainDrawer;
 extern std::unique_ptr<OswAppTutorial> main_tutorialApp;
+extern bool main_delayedAppInit;
+
+#ifdef OSW_EMULATOR
+void resetGlobals();
+#endif
 }

--- a/src/apps/OswAppDrawer.cpp
+++ b/src/apps/OswAppDrawer.cpp
@@ -227,6 +227,21 @@ void OswAppDrawer::onButton(Button id, bool up, ButtonStateNames state) {
 }
 
 #ifdef OSW_EMULATOR
+/**
+ * @brief allow re-use of the drawer instance in the emulator
+ *
+ */
+void OswAppDrawer::reset() {
+    for (auto& category : this->apps) {
+        for (auto& app : category.second) {
+            app.cleanup();
+        }
+    }
+    this->apps.clear();
+    this->current = nullptr;
+    this->highlightApp = nullptr;
+}
+
 void OswAppDrawer::onLoopDebug() {
     if(this->current)
         this->current->get()->onLoopDebug(); // forward to the current app

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -5,4 +5,12 @@ namespace OswGlobals {
 RTC_DATA_ATTR size_t main_AppIndex = OswAppDrawer::UNDEFINED_SLEEP_APP_INDEX;
 OswAppDrawer main_mainDrawer{&main_AppIndex};
 std::unique_ptr<OswAppTutorial> main_tutorialApp;
+bool main_delayedAppInit = true;
+
+#ifdef OSW_EMULATOR
+void resetGlobals() {
+    main_delayedAppInit = true;
+    main_mainDrawer.reset();
+}
+#endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,7 +149,6 @@ void setup() {
 void loop() {
     static time_t lastPowerUpdate = time(nullptr) + 2;  // We consider a run of at least 2 seconds as "success"
     static time_t nextTimezoneUpdate = time(nullptr) + 60; // Already done after sleep -> revisit in a while
-    static bool delayedAppInit = true;
 
 // check possible interaction with ULP program
 #if USE_ULP == 1
@@ -191,8 +190,8 @@ void loop() {
         ESP.restart();
     }
 
-    if (delayedAppInit) {
-        delayedAppInit = false;
+    if (OswGlobals::main_delayedAppInit) {
+        OswGlobals::main_delayedAppInit = false;
 
         // TODO port all v1 apps to v2, to allow for lazy loading (or let them in compat mode)
 


### PR DESCRIPTION
This properly resets the drawer instance as part of the emulator reset.