### PR TITLE
workflows: upload firmware binary

### DIFF
--- a/.github/workflows/test-OS.yml
+++ b/.github/workflows/test-OS.yml
@@ -75,3 +75,8 @@ jobs:
         run: mv include/config.h.example include/config.h
       - name: Compile language ${{ matrix.language }} model ${{ matrix.model }}
         run: python3 .github/buildFirmware.py -l "${{ matrix.language }}" -m "${{ matrix.model }}" -b debug
+      - name: Upload ${{ matrix.os }} firmware artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmwares-${{ matrix.os }}
+          path: "*.bin"


### PR DESCRIPTION
If testing is required for binaries built by OS workflows, it must be provided by the pipeline.