### PR TITLE
Implemented basic BLE server

### DIFF
--- a/docs/firmware/flags.md
+++ b/docs/firmware/flags.md
@@ -6,6 +6,7 @@ The table below list all currently available features of the OSW-OS. These featu
 | `OSW_FEATURE_STATS_STEPS`    | Enable step history (displayed on the watchfaces)                                    | -                                  |
 | `OSW_FEATURE_WIFI`           | Enable all wifi related functions (services, webinterface)                           | -                                  |
 | `OSW_FEATURE_WIFI_ONBOOT`    | Allow the user to enable the wifi on boot                                            | `OSW_FEATURE_WIFI`                 |
+| `OSW_FEATURE_BLE_SERVER`     | Enable BLE server for the watch                                                      | -                                  |
 | `OSW_FEATURE_BLE_MEDIA_CTRL` | Enables media control via BLE                                                        | -                                  |
 | `OSW_FEATURE_LUA`            | Enable LUA scripting support for apps                                                | `LUA_C89_NUMBERS`                  |
 | `SERVICE_BLE_COMPANION=1`    | Enables the BLE Companion Service (unstable, requires custom smartphone application) | -                                  |

--- a/include/config_defaults.h
+++ b/include/config_defaults.h
@@ -86,6 +86,10 @@
 #define CONFIG_FALLBACK_2ND_WIFI_PASS ""
 #endif
 
+#ifndef BLE_ON_BOOT
+#define BLE_ON_BOOT false
+#endif
+
 #ifndef DISPLAY_BRIGHTNESS
 // DISPLAY_MIN_BRIGHTNESS - 255
 #define DISPLAY_BRIGHTNESS 128

--- a/include/config_defaults.h
+++ b/include/config_defaults.h
@@ -245,7 +245,7 @@
 /**
  * Experimentals/Services
  *
- * Keep in mind, that the OSW may not be tested with these flgs (un)set. Be prepared to fix some bugs ;)
+ * Keep in mind, that the OSW may not be tested with these flags (un)set. Be prepared to fix some bugs ;)
  */
 
 // Experimentals (1 = enable, 0 = disable):

--- a/include/config_defaults.h
+++ b/include/config_defaults.h
@@ -242,8 +242,10 @@
 #define TOOL_TIMER_BTN_TIMEOUT 1800
 #endif
 
-/*
- * Experimentals/Services:
+/**
+ * Experimentals/Services
+ *
+ * Keep in mind, that the OSW may not be tested with these flgs (un)set. Be prepared to fix some bugs ;)
  */
 
 // Experimentals (1 = enable, 0 = disable):

--- a/include/gfx_2d_print.h
+++ b/include/gfx_2d_print.h
@@ -453,7 +453,7 @@ class Graphics2DPrint : public Graphics2D, public Print {
      * @brief Set the text size.
      *
      * Size "1" mean a size of 8px height and 6 px width.
-     * Size "2" mean a double size => 18px height x 12px width
+     * Size "2" mean a double size => 16px height x 12px width
      *
      * @param s Size of the text
      */

--- a/include/osw_config_keys.h
+++ b/include/osw_config_keys.h
@@ -24,8 +24,10 @@ class OswConfigKeyRGB;
 
 // All externally accessible keys are listed here (add them to osw_config_keys.cpp oswConfigKeys for config ui)
 namespace OswConfigAllKeys {
-#ifdef OSW_FEATURE_WIFI
+#if defined(OSW_FEATURE_WIFI) || defined(OSW_FEATURE_BLE_SERVER)
 extern OswConfigKeyString hostname;
+#endif
+#ifdef OSW_FEATURE_WIFI
 extern OswConfigKeyBool hostPasswordEnabled;
 extern OswConfigKeyPassword hostPass;
 #ifdef OSW_FEATURE_WIFI_ONBOOT

--- a/include/osw_config_keys.h
+++ b/include/osw_config_keys.h
@@ -40,6 +40,9 @@ extern OswConfigKeyPassword fallbackWifiPass1st;
 extern OswConfigKeyString fallbackWifiSsid2nd;
 extern OswConfigKeyPassword fallbackWifiPass2nd;
 #endif
+#ifdef OSW_FEATURE_BLE_SERVER
+extern OswConfigKeyBool bleBootEnabled;
+#endif
 extern OswConfigKeyRGB themeBackgroundColor;
 extern OswConfigKeyRGB themeBackgroundDimmedColor;
 extern OswConfigKeyRGB themeForegroundColor;

--- a/include/osw_pins.h
+++ b/include/osw_pins.h
@@ -6,8 +6,8 @@
 // SD_MISO 19
 // for SCK, MOSI see TFT
 
-#define GPS_RX 14
-#define GPS_TX 27
+#define GPS_RX 27
+#define GPS_TX 14
 #define GPS_FON 26
 #define GPS_3D_FIX 36
 #define GPS_GEO_FENCE 39
@@ -16,14 +16,10 @@
 #define BTN_1 0
 #define BTN_2 13
 #define BTN_3 33
-#define GPS_RX1 27
-#define GPS_TX1 14
 #elif defined(GPS_EDITION_ROTATED)
 #define BTN_1 13
 #define BTN_2 33
 #define BTN_3 0
-#define GPS_RX1 27
-#define GPS_TX1 14
 #else
 #define BTN_1 0
 #define BTN_2 13

--- a/include/osw_ui.h
+++ b/include/osw_ui.h
@@ -59,6 +59,9 @@ class OswUI {
       private:
         unsigned char countLines(const std::string& message) const;
 
+        const unsigned long notificationDurationPerLinePersistant = 300'000;
+        const unsigned long notificationDurationPerLine = 5'000;
+
         static size_t count;
         const size_t id{};
         const String message{};

--- a/include/osw_ui.h
+++ b/include/osw_ui.h
@@ -110,6 +110,7 @@ class OswUI {
     unsigned int lastBGFlush = 0;
     std::mutex mNotificationsLock;
     std::list<OswUINotification> mNotifications;
+    bool mSelfNeedsRedraw = false;
     OswAppV2* mRootApplication = nullptr;
 };
 

--- a/include/osw_ui.h
+++ b/include/osw_ui.h
@@ -46,16 +46,23 @@ class OswUI {
             return message;
         }
 
+        unsigned char getMessageLines() const {
+            return lines;
+        }
+
         unsigned long getEndTime() const {
             return endTime;
         }
 
-        const static unsigned char sDrawHeight = 16;  // EVERY notification must not be taller than this!
+        unsigned char getDrawHeight() const;
 
       private:
-        size_t id{};
+        unsigned char countLines(const std::string& message) const;
+
         static size_t count;
+        const size_t id{};
         const String message{};
+        const unsigned char lines;
         const unsigned long endTime{};
     };
 

--- a/include/services/NotifierClient.h
+++ b/include/services/NotifierClient.h
@@ -16,6 +16,8 @@ class NotifierClient {
     NotificationData createNotification(int hours, int minutes,
                                         std::string message = {}, std::array<bool, 7> daysOfWeek = {}, bool isPersistent = {});
 
+    NotificationData showToast(std::string message);
+
     std::vector<NotificationData> readNotifications();
 
     void deleteNotification(unsigned id);

--- a/include/services/OswServiceManager.h
+++ b/include/services/OswServiceManager.h
@@ -25,7 +25,12 @@ class OswServiceManager {
 #else
 #define _SERVICE_WIFI 0
 #endif
-    const unsigned workerStackSize = 2048 + (8192 * _SERVICE_WIFI); // If wifi is active, set to same size as core 0
+#ifdef OSW_FEATURE_BLE_SERVER
+#define _SERVICE_BLE 1
+#else
+#define _SERVICE_BLE 0
+#endif
+    const unsigned workerStackSize = 2048 + (8192 * _SERVICE_WIFI) + (2048 * _SERVICE_BLE); // If wifi is active, set to same size as core 0
     const unsigned workerStartupDelay = 2000;
     const unsigned workerLoopDelay = 10;
 

--- a/include/services/OswServiceManager.h
+++ b/include/services/OswServiceManager.h
@@ -19,18 +19,18 @@ class OswServiceManager {
         instance.reset();
     }
 
-    //Temp workaround until #137 is done
+    // Temp workaround until #137 is done
 #ifdef OSW_FEATURE_WIFI
-#define _SERVICE_WIFI 1
+#define _ADDITIONAL_STACK_SIZE_FOR_WIFI 8192
 #else
-#define _SERVICE_WIFI 0
+#define _ADDITIONAL_STACK_SIZE_FOR_WIFI 0
 #endif
 #ifdef OSW_FEATURE_BLE_SERVER
-#define _SERVICE_BLE 1
+#define _ADDITIONAL_STACK_SIZE_FOR_BLE 2048
 #else
-#define _SERVICE_BLE 0
+#define _ADDITIONAL_STACK_SIZE_FOR_BLE 0
 #endif
-    const unsigned workerStackSize = 2048 + (8192 * _SERVICE_WIFI) + (2048 * _SERVICE_BLE); // If wifi is active, set to same size as core 0
+    const unsigned workerStackSize = 2048 + _ADDITIONAL_STACK_SIZE_FOR_WIFI + _ADDITIONAL_STACK_SIZE_FOR_BLE; // base stack size is 2k
     const unsigned workerStartupDelay = 2000;
     const unsigned workerLoopDelay = 10;
 

--- a/include/services/OswServiceTaskBLECompanion.h
+++ b/include/services/OswServiceTaskBLECompanion.h
@@ -1,8 +1,7 @@
-#ifndef OSW_SERVICE_COMPANION_H
-#define OSW_SERVICE_COMPANION_H
+#pragma once
 
-#ifndef OSW_EMULATOR
 #if SERVICE_BLE_COMPANION == 1
+#ifndef OSW_EMULATOR
 #include <BLECharacteristic.h>
 #include <BLEDevice.h>
 #include <osw_hal.h>
@@ -43,6 +42,5 @@ class OswServiceTaskBLECompanion : public OswServiceTask {
     friend class NotificationCallback;
 };
 
-#endif
 #endif
 #endif

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -76,7 +76,7 @@ class OswServiceTaskBLEServer : public OswServiceTask {
             this->bytes[2] = (uint8_t) (value >> 16);
             this->bytes[3] = (uint8_t) (value >> 24);
         */
-        uint8_t bytes[4]; 
+        uint8_t bytesStepsToday[4]; 
     };
     class StepsTotalWeekCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
@@ -87,7 +87,7 @@ class OswServiceTaskBLEServer : public OswServiceTask {
             this->bytes[2] = (uint8_t) (value >> 16);
             this->bytes[3] = (uint8_t) (value >> 24);
         */
-        uint8_t bytes[4]; 
+        uint8_t bytesStepsTotalWeek[4]; 
     };
     class StepsTotalCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
@@ -98,7 +98,7 @@ class OswServiceTaskBLEServer : public OswServiceTask {
             this->bytes[2] = (uint8_t) (value >> 16);
             this->bytes[3] = (uint8_t) (value >> 24);
         */
-        uint8_t bytes[4]; 
+        uint8_t bytesStepsTotal[4]; 
     };
     class StepsAverageCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
@@ -109,7 +109,7 @@ class OswServiceTaskBLEServer : public OswServiceTask {
             this->bytes[2] = (uint8_t) (value >> 16);
             this->bytes[3] = (uint8_t) (value >> 24);
         */
-        uint8_t bytes[4]; 
+        uint8_t bytesStepsAverage[4]; 
     };
     class StepsDayHistoryCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
@@ -133,7 +133,7 @@ class OswServiceTaskBLEServer : public OswServiceTask {
             ...
 
         */
-        uint8_t bytes[4 * 7]; 
+        uint8_t bytesStepsDayHistory[4 * 7]; 
     };
     
 

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -67,6 +67,75 @@ class OswServiceTaskBLEServer : public OswServiceTask {
 
         OswServiceTaskBLEServer* task;
     };
+    class StepsTodayCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        /*
+            uint32_t value;
+            this->bytes[0] = (uint8_t) value; 
+            this->bytes[1] = (uint8_t) (value >> 8);
+            this->bytes[2] = (uint8_t) (value >> 16);
+            this->bytes[3] = (uint8_t) (value >> 24);
+        */
+        uint8_t bytes[4]; 
+    };
+    class StepsTotalWeekCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        /*
+            uint32_t value;
+            this->bytes[0] = (uint8_t) value; 
+            this->bytes[1] = (uint8_t) (value >> 8);
+            this->bytes[2] = (uint8_t) (value >> 16);
+            this->bytes[3] = (uint8_t) (value >> 24);
+        */
+        uint8_t bytes[4]; 
+    };
+    class StepsTotalCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        /*
+            uint32_t value;
+            this->bytes[0] = (uint8_t) value; 
+            this->bytes[1] = (uint8_t) (value >> 8);
+            this->bytes[2] = (uint8_t) (value >> 16);
+            this->bytes[3] = (uint8_t) (value >> 24);
+        */
+        uint8_t bytes[4]; 
+    };
+    class StepsAverageCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        /*
+            uint32_t value;
+            this->bytes[0] = (uint8_t) value; 
+            this->bytes[1] = (uint8_t) (value >> 8);
+            this->bytes[2] = (uint8_t) (value >> 16);
+            this->bytes[3] = (uint8_t) (value >> 24);
+        */
+        uint8_t bytes[4]; 
+    };
+    class StepsDayHistoryCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        /*
+            uint32_t value[7];
+            this->bytes[0] = (uint8_t) value[0];
+            this->bytes[1] = (uint8_t) (value[0] >> 8);
+            this->bytes[2] = (uint8_t) (value[0] >> 16);
+            this->bytes[3] = (uint8_t) (value[0] >> 24);
+
+            this->bytes[4] = (uint8_t) value[1]; 
+            this->bytes[5] = (uint8_t) (value[1] >> 8);
+            this->bytes[6] = (uint8_t) (value[1] >> 16);
+            this->bytes[7] = (uint8_t) (value[1] >> 24);
+
+            this->bytes[8] = (uint8_t) value[2]; 
+            this->bytes[9] = (uint8_t) (value[2] >> 8);
+            this->bytes[10] = (uint8_t) (value[2] >> 16);
+            this->bytes[11] = (uint8_t) (value[2] >> 24);
+
+            ...
+
+        */
+        uint8_t bytes[4 * 7]; 
+    };
+    
 
     /// apply the desired BLE state
     void updateBLEConfig();
@@ -84,6 +153,15 @@ class OswServiceTaskBLEServer : public OswServiceTask {
     NimBLECharacteristic* characteristicSoftRev = nullptr;
     NimBLEService* serviceOsw = nullptr;
     NimBLECharacteristic* characteristicToast = nullptr;
+#if OSW_PLATFORM_ENVIRONMENT_ACCELEROMETER == 1
+    NimBLECharacteristic* characteristicStepCountTotal = nullptr;
+    NimBLECharacteristic* characteristicStepCountTotalWeek = nullptr;
+    NimBLECharacteristic* characteristicStepCountToday = nullptr;
+#ifdef OSW_FEATURE_STATS_STEPS
+    NimBLECharacteristic* characteristicStepCountAverage = nullptr;
+    NimBLECharacteristic* characteristicStepCountHistory = nullptr;
+#endif
+#endif
 
     // ↓ our own stuff
     NotifierClient notify = NotifierClient("osw.ble.server");

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifdef OSW_FEATURE_BLE_SERVER
 #include "osw_service.h"
+#include "services/NotifierClient.h"
 
 #define CONFIG_BT_NIMBLE_ROLE_PERIPHERAL
 #include <NimBLEDevice.h>
@@ -27,9 +28,12 @@ class OswServiceTaskBLEServer : public OswServiceTask {
         void onConnect(BLEServer* pServer);
         void onDisconnect(BLEServer* pServer);
         uint32_t onPassKeyRequest();
-        bool onConfirmPIN(uint32_t pass_key);
+        bool onConfirmPIN(uint32_t pass_key) {
+            return false; // we only report display-only
+        };
 
         OswServiceTaskBLEServer* task;
+        NotifierClient notify = NotifierClient("osw.ble.server");
     };
     class BatteryLevelCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -5,7 +5,7 @@
 #define CONFIG_BT_NIMBLE_ROLE_PERIPHERAL
 #include <NimBLEDevice.h>
 
-class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
+class OswServiceTaskBLEServer : public OswServiceTask {
   public:
     OswServiceTaskBLEServer() {};
     virtual void setup() override;
@@ -19,6 +19,18 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
 
     void updateName();
   private:
+    class ServerCallbacks: public NimBLEServerCallbacks {
+      public:
+        ServerCallbacks(OswServiceTaskBLEServer* task): task(task) {};
+
+      private:
+        void onConnect(BLEServer* pServer);
+        void onDisconnect(BLEServer* pServer);
+        uint32_t onPassKeyRequest();
+        bool onConfirmPIN(uint32_t pass_key);
+
+        OswServiceTaskBLEServer* task;
+    };
     class BatteryLevelCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
         uint8_t byte = 0; // will be read from
@@ -47,12 +59,6 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
     /// apply the desired BLE state
     void updateBLEConfig();
 
-    // ↓ NimBLEServerCallbacks
-    void onConnect(BLEServer* pServer);
-    void onDisconnect(BLEServer* pServer);
-    uint32_t onPassKeyRequest();
-    bool onConfirmPIN(uint32_t pass_key);
-
     // ↓ managed by NimBLE
     NimBLEServer* server = nullptr; // if set, this is considered as "enabled"
     NimBLEService* serviceBat = nullptr;
@@ -69,11 +75,5 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
     bool bootDone = false;
     bool enabled = false;
     char name[8]; // BLE advertising only support up to 8 bytes
-    BatteryLevelCharacteristicCallbacks battery;
-    BatteryLevelStatusCharacteristicCallbacks batteryStatus;
-    CurrentTimeCharacteristicCallbacks currentTime;
-    FirmwareRevisionCharacteristicCallbacks firmwareRevision;
-    HardwareRevisionCharacteristicCallbacks hardwareRevision;
-    SoftwareRevisionCharacteristicCallbacks softwareRevision;
 };
 #endif

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -31,6 +31,18 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
         uint8_t bytes[9+1]; // will be read from (9 exact-time-256, 1 reason)
     };
+    class FirmwareRevisionCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        String value = "Open-Smartwatch OS";
+    };
+    class HardwareRevisionCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        String value;
+    };
+    class SoftwareRevisionCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        String value;
+    };
 
     /// apply the desired BLE state
     void updateBLEConfig();
@@ -48,6 +60,10 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
     NimBLECharacteristic* characteristicBatStat = nullptr;
     NimBLEService* serviceTime = nullptr;
     NimBLECharacteristic* characteristicCurTime = nullptr;
+    NimBLEService* serviceDevice = nullptr;
+    NimBLECharacteristic* characteristicFirmRev = nullptr;
+    NimBLECharacteristic* characteristicHardRev = nullptr;
+    NimBLECharacteristic* characteristicSoftRev = nullptr;
 
     // ↓ our own stuff
     bool bootDone = false;
@@ -56,5 +72,8 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
     BatteryLevelCharacteristicCallbacks battery;
     BatteryLevelStatusCharacteristicCallbacks batteryStatus;
     CurrentTimeCharacteristicCallbacks currentTime;
+    FirmwareRevisionCharacteristicCallbacks firmwareRevision;
+    HardwareRevisionCharacteristicCallbacks hardwareRevision;
+    SoftwareRevisionCharacteristicCallbacks softwareRevision;
 };
 #endif

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -69,71 +69,23 @@ class OswServiceTaskBLEServer : public OswServiceTask {
     };
     class StepsTodayCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
-        /*
-            uint32_t value;
-            this->bytes[0] = (uint8_t) value; 
-            this->bytes[1] = (uint8_t) (value >> 8);
-            this->bytes[2] = (uint8_t) (value >> 16);
-            this->bytes[3] = (uint8_t) (value >> 24);
-        */
-        uint8_t bytesStepsToday[4]; 
+        uint8_t bytesStepsToday[4]; // this is a 4-byte array of a uint_32_t number
     };
     class StepsTotalWeekCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
-        /*
-            uint32_t value;
-            this->bytes[0] = (uint8_t) value; 
-            this->bytes[1] = (uint8_t) (value >> 8);
-            this->bytes[2] = (uint8_t) (value >> 16);
-            this->bytes[3] = (uint8_t) (value >> 24);
-        */
-        uint8_t bytesStepsTotalWeek[4]; 
+        uint8_t bytesStepsTotalWeek[4]; // this is a 4-byte array of a uint_32_t number
     };
     class StepsTotalCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
-        /*
-            uint32_t value;
-            this->bytes[0] = (uint8_t) value; 
-            this->bytes[1] = (uint8_t) (value >> 8);
-            this->bytes[2] = (uint8_t) (value >> 16);
-            this->bytes[3] = (uint8_t) (value >> 24);
-        */
-        uint8_t bytesStepsTotal[4]; 
+        uint8_t bytesStepsTotal[4]; // this is a 4-byte array of a uint_32_t number
     };
     class StepsAverageCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
-        /*
-            uint32_t value;
-            this->bytes[0] = (uint8_t) value; 
-            this->bytes[1] = (uint8_t) (value >> 8);
-            this->bytes[2] = (uint8_t) (value >> 16);
-            this->bytes[3] = (uint8_t) (value >> 24);
-        */
-        uint8_t bytesStepsAverage[4]; 
+        uint8_t bytesStepsAverage[4]; // this is a 4-byte array of a uint_32_t number
     };
     class StepsDayHistoryCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
-        /*
-            uint32_t value[7];
-            this->bytes[0] = (uint8_t) value[0];
-            this->bytes[1] = (uint8_t) (value[0] >> 8);
-            this->bytes[2] = (uint8_t) (value[0] >> 16);
-            this->bytes[3] = (uint8_t) (value[0] >> 24);
-
-            this->bytes[4] = (uint8_t) value[1]; 
-            this->bytes[5] = (uint8_t) (value[1] >> 8);
-            this->bytes[6] = (uint8_t) (value[1] >> 16);
-            this->bytes[7] = (uint8_t) (value[1] >> 24);
-
-            this->bytes[8] = (uint8_t) value[2]; 
-            this->bytes[9] = (uint8_t) (value[2] >> 8);
-            this->bytes[10] = (uint8_t) (value[2] >> 16);
-            this->bytes[11] = (uint8_t) (value[2] >> 24);
-
-            ...
-
-        */
-        uint8_t bytesStepsDayHistory[4 * 7]; 
+        uint8_t bytesStepsDayHistory[4 * 7]; // this is a 28-byte array of a seven uint_32_t number
     };
     
 

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -13,12 +13,19 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
     virtual void stop() override;
     ~OswServiceTaskBLEServer() {};
 
+    void enable();
+    void disable();
+    bool isEnabled();
+
     void updateName();
   private:
     class BatteryCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
         uint8_t byte = 0; // will be read from
     };
+
+    /// apply the desired BLE state
+    void updateBLEConfig();
 
     // ↓ NimBLEServerCallbacks
     void onConnect(BLEServer* pServer);
@@ -27,11 +34,13 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
     bool onConfirmPIN(uint32_t pass_key);
 
     // ↓ managed by NimBLE
-    NimBLEServer* server = nullptr;
+    NimBLEServer* server = nullptr; // if set, this is considered as "enabled"
     BLEService* serviceBat = nullptr;
     NimBLECharacteristic* characteristicBat = nullptr;
 
     // ↓ our own stuff
+    bool bootDone = false;
+    bool enabled = false;
     char name[8]; // BLE advertising only support up to 8 bytes
     BatteryCharacteristicCallbacks battery;
 };

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -1,0 +1,38 @@
+#pragma once
+#ifdef OSW_FEATURE_BLE_SERVER
+#include "osw_service.h"
+
+#define CONFIG_BT_NIMBLE_ROLE_PERIPHERAL
+#include <NimBLEDevice.h>
+
+class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
+  public:
+    OswServiceTaskBLEServer() {};
+    virtual void setup() override;
+    virtual void loop() override;
+    virtual void stop() override;
+    ~OswServiceTaskBLEServer() {};
+
+    void updateName();
+  private:
+    class BatteryCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        uint8_t byte = 0; // will be read from
+    };
+
+    // ↓ NimBLEServerCallbacks
+    void onConnect(BLEServer* pServer);
+    void onDisconnect(BLEServer* pServer);
+    uint32_t onPassKeyRequest();
+    bool onConfirmPIN(uint32_t pass_key);
+
+    // ↓ managed by NimBLE
+    NimBLEServer* server = nullptr;
+    BLEService* serviceBat = nullptr;
+    NimBLECharacteristic* characteristicBat = nullptr;
+
+    // ↓ our own stuff
+    char name[8]; // BLE advertising only support up to 8 bytes
+    BatteryCharacteristicCallbacks battery;
+};
+#endif

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -44,7 +44,7 @@ class OswServiceTaskBLEServer : public OswServiceTask {
     };
     class CurrentTimeCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
-        uint8_t bytes[9+1]; // will be read from (9 exact-time-256, 1 reason)
+        uint8_t bytesCurrentTime[9+1]; // will be read from (9 exact-time-256, 1 reason)
     };
     class FirmwareRevisionCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -19,9 +19,13 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
 
     void updateName();
   private:
-    class BatteryCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+    class BatteryLevelCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
         uint8_t byte = 0; // will be read from
+    };
+    class BatteryLevelStatusCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        uint8_t bytes[1+2+1]; // will be read from (1 flag, 2 power-state, 1 battery-level)
     };
 
     /// apply the desired BLE state
@@ -37,11 +41,13 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
     NimBLEServer* server = nullptr; // if set, this is considered as "enabled"
     BLEService* serviceBat = nullptr;
     NimBLECharacteristic* characteristicBat = nullptr;
+    NimBLECharacteristic* characteristicBatStat = nullptr;
 
     // ↓ our own stuff
     bool bootDone = false;
     bool enabled = false;
     char name[8]; // BLE advertising only support up to 8 bytes
-    BatteryCharacteristicCallbacks battery;
+    BatteryLevelCharacteristicCallbacks battery;
+    BatteryLevelStatusCharacteristicCallbacks batteryStatus;
 };
 #endif

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -33,7 +33,6 @@ class OswServiceTaskBLEServer : public OswServiceTask {
         };
 
         OswServiceTaskBLEServer* task;
-        NotifierClient notify = NotifierClient("osw.ble.server");
     };
     class BatteryLevelCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
@@ -59,6 +58,15 @@ class OswServiceTaskBLEServer : public OswServiceTask {
         void onRead(NimBLECharacteristic* pCharacteristic);
         String value;
     };
+    class ToastCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+      public:
+        ToastCharacteristicCallbacks(OswServiceTaskBLEServer* task): task(task) {};
+
+      private:
+        void onWrite(NimBLECharacteristic* pCharacteristic);
+
+        OswServiceTaskBLEServer* task;
+    };
 
     /// apply the desired BLE state
     void updateBLEConfig();
@@ -74,8 +82,11 @@ class OswServiceTaskBLEServer : public OswServiceTask {
     NimBLECharacteristic* characteristicFirmRev = nullptr;
     NimBLECharacteristic* characteristicHardRev = nullptr;
     NimBLECharacteristic* characteristicSoftRev = nullptr;
+    NimBLEService* serviceOsw = nullptr;
+    NimBLECharacteristic* characteristicToast = nullptr;
 
     // ↓ our own stuff
+    NotifierClient notify = NotifierClient("osw.ble.server");
     bool bootDone = false;
     bool enabled = false;
     char name[8]; // BLE advertising only support up to 8 bytes

--- a/include/services/OswServiceTaskBLEServer.h
+++ b/include/services/OswServiceTaskBLEServer.h
@@ -27,6 +27,10 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
         void onRead(NimBLECharacteristic* pCharacteristic);
         uint8_t bytes[1+2+1]; // will be read from (1 flag, 2 power-state, 1 battery-level)
     };
+    class CurrentTimeCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+        void onRead(NimBLECharacteristic* pCharacteristic);
+        uint8_t bytes[9+1]; // will be read from (9 exact-time-256, 1 reason)
+    };
 
     /// apply the desired BLE state
     void updateBLEConfig();
@@ -39,9 +43,11 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
 
     // ↓ managed by NimBLE
     NimBLEServer* server = nullptr; // if set, this is considered as "enabled"
-    BLEService* serviceBat = nullptr;
+    NimBLEService* serviceBat = nullptr;
     NimBLECharacteristic* characteristicBat = nullptr;
     NimBLECharacteristic* characteristicBatStat = nullptr;
+    NimBLEService* serviceTime = nullptr;
+    NimBLECharacteristic* characteristicCurTime = nullptr;
 
     // ↓ our own stuff
     bool bootDone = false;
@@ -49,5 +55,6 @@ class OswServiceTaskBLEServer : public OswServiceTask, NimBLEServerCallbacks {
     char name[8]; // BLE advertising only support up to 8 bytes
     BatteryLevelCharacteristicCallbacks battery;
     BatteryLevelStatusCharacteristicCallbacks batteryStatus;
+    CurrentTimeCharacteristicCallbacks currentTime;
 };
 #endif

--- a/include/services/OswServiceTaskConsole.h
+++ b/include/services/OswServiceTaskConsole.h
@@ -10,6 +10,14 @@ class OswServiceTaskConsole : public OswServiceTask {
     ~OswServiceTaskConsole() {};
 
   private:
+    enum class Mode {
+        Generic,
+        Configuration,
+#ifdef OSW_FEATURE_BLE_SERVER
+        Ble
+#endif
+    };
+
     void newPrompt();
     void showPrompt();
     void runPrompt();
@@ -18,5 +26,5 @@ class OswServiceTaskConsole : public OswServiceTask {
     std::string m_inputBuffer;
     bool m_locked = false;
     unsigned char m_lockCounter = 0;
-    bool m_configuring = false;
+    Mode m_mode = Mode::Generic;
 };

--- a/include/services/OswServiceTasks.h
+++ b/include/services/OswServiceTasks.h
@@ -1,15 +1,20 @@
 #include "osw_service.h"
 
+#if SERVICE_BLE_COMPANION == 1
+class OswServiceTaskBLECompanion;
+#endif
 class OswServiceTaskExample;
 class OswServiceTaskMemMonitor;
 class OswServiceTaskNotifier;
+#ifdef OSW_FEATURE_BLE_SERVER
+class OswServiceTaskBLEServer;
+#endif
 #ifdef OSW_FEATURE_WIFI
 class OswServiceTaskWiFi;
 class OswServiceTaskWebserver;
 #endif
 namespace OswServiceAllTasks {
 #if SERVICE_BLE_COMPANION == 1
-class OswServiceTaskBLECompanion;
 extern OswServiceTaskBLECompanion bleCompanion;
 #endif
 // extern OswServiceTaskExample example;
@@ -19,6 +24,9 @@ extern OswServiceTaskWebserver webserver;
 #endif
 #if OSW_SERVICE_NOTIFIER == 1
 extern OswServiceTaskNotifier notifier;
+#endif
+#ifdef OSW_FEATURE_BLE_SERVER
+extern OswServiceTaskBLEServer bleServer;
 #endif
 extern OswServiceTaskMemMonitor memory;
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,6 +34,7 @@ lib_deps =
 	bblanchon/ArduinoJson@6.21.5
 	finitespace/BME280@3.0.0 ; TODO Use the more popular Adafruit BME280 Library instead (also true for others?)?
 	mprograms/QMC5883LCompass@1.2.3
+	h2zero/NimBLE-Arduino@^1.4.1
 upload_speed = 460800
 monitor_speed = 115200
 ; Define additional build stage scripts - used to "compile" the html or define additional information

--- a/src/hal/gps.cpp
+++ b/src/hal/gps.cpp
@@ -18,7 +18,7 @@ NMEAGPS* OswHal::gps(void) {
 void OswHal::setupGps(void) {
     pinMode(GPS_FON, OUTPUT);
     digitalWrite(GPS_FON, HIGH);
-    SerialGPS.begin(9600, SERIAL_8N1, GPS_RX1, GPS_TX1);
+    SerialGPS.begin(9600, SERIAL_8N1, GPS_RX, GPS_TX);
 }
 bool OswHal::hasGPS(void) {
     return _hasGPS;

--- a/src/osw_config.cpp
+++ b/src/osw_config.cpp
@@ -13,6 +13,8 @@
 #include <osw_hal.h> // For timezone reloading
 #include <osw_ui.h> // For color reloading
 #include "apps/watchfaces/OswAppWatchfaceDigital.h"
+#include <services/OswServiceTasks.h>
+#include <services/OswServiceTaskBLEServer.h>
 
 std::unique_ptr<OswConfig> OswConfig::instance = nullptr;
 
@@ -173,4 +175,7 @@ void OswConfig::notifyChange() {
     // OswUI::getInstance()->resetTextColors(); // nope - this is done by the ui itself
     OswHal::getInstance()->updateTimezoneOffsets();
     OswAppWatchfaceDigital::refreshDateFormatCache();
+#ifdef OSW_FEATURE_BLE_SERVER
+    OswServiceAllTasks::bleServer.updateName();
+#endif
 }

--- a/src/osw_config_keys.cpp
+++ b/src/osw_config_keys.cpp
@@ -32,8 +32,10 @@
 // Add your keys to this namespace (do not forget to also declare them inside the header)
 namespace OswConfigAllKeys {
 // TODO Translate all this?
+#if defined(OSW_FEATURE_WIFI) || defined(OSW_FEATURE_BLE_SERVER)
+OswConfigKeyString hostname("i", "System", "Hostname", "Used e.g. for the wifi station or BLE device name", DEVICE_NAME);
+#endif
 #ifdef OSW_FEATURE_WIFI
-OswConfigKeyString hostname("i", "WiFi", "Hostname", "Used e.g. for the wifi station", DEVICE_NAME);
 OswConfigKeyBool hostPasswordEnabled("i3", "WiFi", "Enable AutoAP Password", nullptr, true);
 OswConfigKeyPassword hostPass("i2", "WiFi", "AutoAP Password", "Password to use for AutoAP (leave empty to use random)", "");
 
@@ -51,7 +53,7 @@ OswConfigKeyString fallbackWifiSsid2nd("a2", "WiFi", "3rd SSID", "Leave empty to
 OswConfigKeyPassword fallbackWifiPass2nd("b2", "WiFi", "3rd Password", nullptr, CONFIG_FALLBACK_2ND_WIFI_PASS);
 #endif
 #ifdef OSW_FEATURE_BLE_SERVER
-OswConfigKeyBool bleBootEnabled("f", "BLE", "Enable on boot", "This will drain your battery faster!", BLE_ON_BOOT);
+OswConfigKeyBool bleBootEnabled("f", "System", "Enable BLE on boot", "This will drain your battery faster!", BLE_ON_BOOT);
 #endif
 
 OswConfigKeyShort settingDisplayBrightness("s1", "Display", "Display Brightness", "From 0 to 255",
@@ -130,9 +132,11 @@ OswConfigKeyString weatherState1("ws1","Weather", "Country code", "",OPENWEATHER
 
 // ...and also here, if you want to load them during boot and make them available in the configuration ui
 OswConfigKey* oswConfigKeys[] = {
+#if defined(OSW_FEATURE_WIFI) || defined(OSW_FEATURE_BLE_SERVER)
+    & OswConfigAllKeys::hostname,
+#endif
 #ifdef OSW_FEATURE_WIFI
     // wifi
-    &OswConfigAllKeys::hostname,
     &OswConfigAllKeys::wifiSsid, &OswConfigAllKeys::wifiPass,
     &OswConfigAllKeys::fallbackWifiSsid1st,&OswConfigAllKeys::fallbackWifiPass1st,
     &OswConfigAllKeys::fallbackWifiSsid2nd,&OswConfigAllKeys::fallbackWifiPass2nd,

--- a/src/osw_config_keys.cpp
+++ b/src/osw_config_keys.cpp
@@ -50,6 +50,9 @@ OswConfigKeyPassword fallbackWifiPass1st("b1", "WiFi", "2nd Password", nullptr, 
 OswConfigKeyString fallbackWifiSsid2nd("a2", "WiFi", "3rd SSID", "Leave empty to disable", CONFIG_FALLBACK_2ND_WIFI_SSID);
 OswConfigKeyPassword fallbackWifiPass2nd("b2", "WiFi", "3rd Password", nullptr, CONFIG_FALLBACK_2ND_WIFI_PASS);
 #endif
+#ifdef OSW_FEATURE_BLE_SERVER
+OswConfigKeyBool bleBootEnabled("f", "BLE", "Enable on boot", "This will drain your battery faster!", BLE_ON_BOOT);
+#endif
 
 OswConfigKeyShort settingDisplayBrightness("s1", "Display", "Display Brightness", "From 0 to 255",
         DISPLAY_BRIGHTNESS);
@@ -137,7 +140,10 @@ OswConfigKey* oswConfigKeys[] = {
     & OswConfigAllKeys::wifiBootEnabled,
 #endif
     & OswConfigAllKeys::wifiAlwaysNTPEnabled, &OswConfigAllKeys::wifiAutoAP,
-    &OswConfigAllKeys::hostPasswordEnabled, &OswConfigAllKeys::hostPass,
+    & OswConfigAllKeys::hostPasswordEnabled, &OswConfigAllKeys::hostPass,
+#endif
+#ifdef OSW_FEATURE_BLE_SERVER
+    & OswConfigAllKeys::bleBootEnabled,
 #endif
     // display
     &OswConfigAllKeys::settingDisplayTimeout, &OswConfigAllKeys::settingDisplayBrightness,

--- a/src/osw_ui.cpp
+++ b/src/osw_ui.cpp
@@ -105,12 +105,14 @@ void OswUI::loop() {
         for (auto it = this->mNotifications.begin(); it != this->mNotifications.end();) {
             if (it->getEndTime() <= millis() || notificationsDismissed) {
                 it = this->mNotifications.erase(it);
+                this->mSelfNeedsRedraw = true;
             } else {
                 ++it;
             }
         }
         if (notificationsDismissed) {
             // Don't propagate the OswHall::btnHasGoneDown() event further
+            this->mSelfNeedsRedraw = true;
             return;
         }
     }
@@ -129,7 +131,8 @@ void OswUI::loop() {
 #endif
 
     // Lock UI for drawing
-    if(rootApp->getNeedsRedraw() or (rootApp->getViewFlags() & OswAppV2::ViewFlags::NO_FPS_LIMIT)) {
+    if(rootApp->getNeedsRedraw() or (rootApp->getViewFlags() & OswAppV2::ViewFlags::NO_FPS_LIMIT) or
+            this->mSelfNeedsRedraw) {
         if(not (rootApp->getViewFlags() & OswAppV2::ViewFlags::NO_FPS_LIMIT) and this->mEnableTargetFPS and (millis() - lastFlush) < (1000 / this->mTargetFPS))
             return; // Early abort if we would draw too fast
         std::lock_guard<std::mutex> guard(*this->drawLock); // Make sure to not modify the notifications vector during drawing
@@ -180,6 +183,7 @@ void OswUI::loop() {
         OswHal::getInstance()->flushCanvas();
         lastFlush = millis();
         rootApp->resetNeedsRedraw(); // indirect convention: we will clear the redraw flag after drawing (so if you set it again during onDraw(), you will need to move that to the onLoop())
+        this->mSelfNeedsRedraw = false;
     }
 }
 
@@ -197,6 +201,7 @@ size_t OswUI::showNotification(std::string message, bool isPersistent) {
     std::lock_guard<std::mutex> guard(this->mNotificationsLock);  // Make sure to not modify the notifications vector during drawing
     auto notification = OswUI::OswUINotification{std::move(message), isPersistent};
     this->mNotifications.push_back(notification);
+    this->mSelfNeedsRedraw = true;
     return notification.getId();
 }
 
@@ -205,6 +210,7 @@ void OswUI::hideNotification(size_t id) {
     for (auto it = this->mNotifications.begin(); it != this->mNotifications.end(); ++it) {
         if (it->getId() == id) {
             this->mNotifications.erase(it);
+            this->mSelfNeedsRedraw = true;
             return;
         }
     }

--- a/src/osw_ui.cpp
+++ b/src/osw_ui.cpp
@@ -309,7 +309,7 @@ void OswUI::OswUIProgress::draw() {
 size_t OswUI::OswUINotification::count{};
 
 OswUI::OswUINotification::OswUINotification(std::string message, bool isPersistent)
-    : id(count), message{message.c_str()}, lines(countLines(message)), endTime{millis() + (isPersistent ? 300'000 : 5'000) * lines} {
+    : id(count), message{message.c_str()}, lines(countLines(message)), endTime{millis() + (isPersistent ? notificationDurationPerLinePersistant : notificationDurationPerLine) * lines} {
     ++count;
 }
 

--- a/src/services/NotifierClient.cpp
+++ b/src/services/NotifierClient.cpp
@@ -13,6 +13,17 @@ NotificationData NotifierClient::createNotification(int hours, int minutes,
     return OswServiceAllTasks::notifier.createNotification(hours, minutes, publisher, std::move(message), std::move(daysOfWeek), isPersistent);
 }
 
+/**
+ * @brief Shorthand to queue a notification to instantly displayed as a "toast".
+ *
+ * @param message
+ * @return NotificationData
+ */
+NotificationData NotifierClient::showToast(std::string message) {
+    auto now = std::chrono::system_clock::from_time_t(OswHal::getInstance()->getUTCTime());
+    return OswServiceAllTasks::notifier.createNotification(std::chrono::time_point_cast<std::chrono::seconds>(now), publisher, std::move(message), std::array<bool, 7> {true, true, true, true, true, true, true}, false);
+}
+
 std::vector<NotificationData> NotifierClient::readNotifications() {
     return OswServiceAllTasks::notifier.readNotifications(publisher);
 }

--- a/src/services/OswServiceTaskBLECompanion.cpp
+++ b/src/services/OswServiceTaskBLECompanion.cpp
@@ -1,9 +1,5 @@
-#ifndef OSW_EMULATOR
-
 #if SERVICE_BLE_COMPANION == 1
-#ifdef OSW_FEATURE_WIFI
-#error "The RAM on all current OSW models is not big enough to hold both WiFi AND Bluetooth stacks during runtime. This WILL lead to a crash. Please only use one of these features simultaneously!"
-#endif
+#ifndef OSW_EMULATOR
 
 #include "./services/OswServiceTaskBLECompanion.h"
 #include "osw_hal.h"

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -304,7 +304,7 @@ void OswServiceTaskBLEServer::CurrentTimeCharacteristicCallbacks::onRead(NimBLEC
     OswDate oswDate;
     OswHal::getInstance()->getDate(offset, oswDate);
     OswTime oswTime;
-    OswHal::getInstance()->getUTCTime(oswTime);
+    OswHal::getInstance()->getTime(offset, oswTime);
 
     this->bytesCurrentTime[0] = (uint8_t) oswDate.year; // Exact Time 256 -> Day Date Time -> Date Time -> Year #1
     this->bytesCurrentTime[1] = (uint8_t) (oswDate.year >> 8); // Exact Time 256 -> Day Date Time -> Date Time -> Year #2

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -151,33 +151,33 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
 
 #if OSW_PLATFORM_ENVIRONMENT_ACCELEROMETER == 1
             this->characteristicStepCountToday = this->serviceOsw->createCharacteristic(
-                                              STEP_COUNT_TODAY_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
-                                          );
+                    STEP_COUNT_TODAY_CHARACTERISTIC_UUID,
+                    NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                                 );
             this->characteristicStepCountToday->setCallbacks(new StepsTodayCharacteristicCallbacks());
 
             this->characteristicStepCountTotal = this->serviceOsw->createCharacteristic(
-                                              STEP_COUNT_TOTAL_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
-                                          );
+                    STEP_COUNT_TOTAL_CHARACTERISTIC_UUID,
+                    NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                                 );
             this->characteristicStepCountTotal->setCallbacks(new StepsTotalCharacteristicCallbacks());
 
             this->characteristicStepCountTotalWeek = this->serviceOsw->createCharacteristic(
-                                              STEP_COUNT_TOTAL_WEEK_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
-                                          );
+                        STEP_COUNT_TOTAL_WEEK_CHARACTERISTIC_UUID,
+                        NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                    );
             this->characteristicStepCountTotalWeek->setCallbacks(new StepsTotalWeekCharacteristicCallbacks());
 #ifdef OSW_FEATURE_STATS_STEPS
             this->characteristicStepCountAverage = this->serviceOsw->createCharacteristic(
-                                              STEP_COUNT_AVERAGE_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
-                                          );
+                    STEP_COUNT_AVERAGE_CHARACTERISTIC_UUID,
+                    NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                                   );
             this->characteristicStepCountAverage->setCallbacks(new StepsAverageCharacteristicCallbacks());
 
             this->characteristicStepCountHistory = this->serviceOsw->createCharacteristic(
-                                              STEP_COUNT_DAY_HISTORY_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
-                                          );
+                    STEP_COUNT_DAY_HISTORY_CHARACTERISTIC_UUID,
+                    NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                                   );
             this->characteristicStepCountHistory->setCallbacks(new StepsDayHistoryCharacteristicCallbacks());
 #endif
 #endif
@@ -301,25 +301,19 @@ void OswServiceTaskBLEServer::BatteryLevelStatusCharacteristicCallbacks::onRead(
 
 void OswServiceTaskBLEServer::CurrentTimeCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
     time_t offset = 0;
-    uint32_t day;
-    uint32_t month;
-    uint32_t year;
-    OswHal::getInstance()->getDate(offset, &day, &month, &year);
-    uint32_t hour;
-    uint32_t minute;
-    uint32_t second;
-    OswHal::getInstance()->getUTCTime(&hour, &minute, &second);
-    uint32_t dow;
-    OswHal::getInstance()->getDate(offset, &day, &dow);
+    OswDate oswDate;
+    OswHal::getInstance()->getDate(offset, oswDate);
+    OswTime oswTime;
+    OswHal::getInstance()->getUTCTime(oswTime);
 
-    this->bytesCurrentTime[0] = (uint8_t) year; // Exact Time 256 -> Day Date Time -> Date Time -> Year #1
-    this->bytesCurrentTime[1] = (uint8_t) (year >> 8); // Exact Time 256 -> Day Date Time -> Date Time -> Year #2
-    this->bytesCurrentTime[2] = (uint8_t) month; // Exact Time 256 -> Day Date Time -> Date Time -> Month
-    this->bytesCurrentTime[3] = (uint8_t) day; // Exact Time 256 -> Day Date Time -> Date Time -> Day
-    this->bytesCurrentTime[4] = (uint8_t) hour; // Exact Time 256 -> Day Date Time -> Date Time -> Hours
-    this->bytesCurrentTime[5] = (uint8_t) minute; // Exact Time 256 -> Day Date Time -> Date Time -> Minutes
-    this->bytesCurrentTime[6] = (uint8_t) second; // Exact Time 256 -> Day Date Time -> Date Time -> Seconds
-    this->bytesCurrentTime[7] = (uint8_t) (dow == 0 ? 7 : dow); // Exact Time 256 -> Day Date Time -> Day of Week
+    this->bytesCurrentTime[0] = (uint8_t) oswDate.year; // Exact Time 256 -> Day Date Time -> Date Time -> Year #1
+    this->bytesCurrentTime[1] = (uint8_t) (oswDate.year >> 8); // Exact Time 256 -> Day Date Time -> Date Time -> Year #2
+    this->bytesCurrentTime[2] = (uint8_t) oswDate.month; // Exact Time 256 -> Day Date Time -> Date Time -> Month
+    this->bytesCurrentTime[3] = (uint8_t) oswDate.day; // Exact Time 256 -> Day Date Time -> Date Time -> Day
+    this->bytesCurrentTime[4] = (uint8_t) oswTime.hour; // Exact Time 256 -> Day Date Time -> Date Time -> Hours
+    this->bytesCurrentTime[5] = (uint8_t) oswTime.minute; // Exact Time 256 -> Day Date Time -> Date Time -> Minutes
+    this->bytesCurrentTime[6] = (uint8_t) oswTime.second; // Exact Time 256 -> Day Date Time -> Date Time -> Seconds
+    this->bytesCurrentTime[7] = (uint8_t) (oswDate.weekDay == 0 ? 7 : oswDate.weekDay); // Exact Time 256 -> Day Date Time -> Day of Week
     this->bytesCurrentTime[8] = 0b00000000; // Exact Time 256 -> Fractions256
     this->bytesCurrentTime[9] = 0b00000001; // Adjust Reason: External Reference Time Update
     pCharacteristic->setValue(this->bytesCurrentTime, sizeof(this->bytesCurrentTime));
@@ -379,9 +373,8 @@ void OswServiceTaskBLEServer::StepsAverageCharacteristicCallbacks::onRead(NimBLE
 }
 
 void OswServiceTaskBLEServer::StepsDayHistoryCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
-   
-    for (uint8_t indexOfWeek = 0; indexOfWeek < 7; indexOfWeek++)
-    { 
+
+    for (uint8_t indexOfWeek = 0; indexOfWeek < 7; indexOfWeek++) {
         uint32_t value = OswHal::getInstance()->environment()->getStepsOnDay(indexOfWeek, false);
         this->bytesStepsDayHistory[0 + indexOfWeek * 4] = (uint8_t) value;
         this->bytesStepsDayHistory[1 + indexOfWeek * 4] = (uint8_t) (value >> 8);

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -312,17 +312,17 @@ void OswServiceTaskBLEServer::CurrentTimeCharacteristicCallbacks::onRead(NimBLEC
     uint32_t dow;
     OswHal::getInstance()->getDate(offset, &day, &dow);
 
-    this->bytes[0] = (uint8_t) year; // Exact Time 256 -> Day Date Time -> Date Time -> Year #1
-    this->bytes[1] = (uint8_t) (year >> 8); // Exact Time 256 -> Day Date Time -> Date Time -> Year #2
-    this->bytes[2] = (uint8_t) month; // Exact Time 256 -> Day Date Time -> Date Time -> Month
-    this->bytes[3] = (uint8_t) day; // Exact Time 256 -> Day Date Time -> Date Time -> Day
-    this->bytes[4] = (uint8_t) hour; // Exact Time 256 -> Day Date Time -> Date Time -> Hours
-    this->bytes[5] = (uint8_t) minute; // Exact Time 256 -> Day Date Time -> Date Time -> Minutes
-    this->bytes[6] = (uint8_t) second; // Exact Time 256 -> Day Date Time -> Date Time -> Seconds
-    this->bytes[7] = (uint8_t) (dow == 0 ? 7 : dow); // Exact Time 256 -> Day Date Time -> Day of Week
-    this->bytes[8] = 0b00000000; // Exact Time 256 -> Fractions256
-    this->bytes[9] = 0b00000001; // Adjust Reason: External Reference Time Update
-    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+    this->bytesCurrentTime[0] = (uint8_t) year; // Exact Time 256 -> Day Date Time -> Date Time -> Year #1
+    this->bytesCurrentTime[1] = (uint8_t) (year >> 8); // Exact Time 256 -> Day Date Time -> Date Time -> Year #2
+    this->bytesCurrentTime[2] = (uint8_t) month; // Exact Time 256 -> Day Date Time -> Date Time -> Month
+    this->bytesCurrentTime[3] = (uint8_t) day; // Exact Time 256 -> Day Date Time -> Date Time -> Day
+    this->bytesCurrentTime[4] = (uint8_t) hour; // Exact Time 256 -> Day Date Time -> Date Time -> Hours
+    this->bytesCurrentTime[5] = (uint8_t) minute; // Exact Time 256 -> Day Date Time -> Date Time -> Minutes
+    this->bytesCurrentTime[6] = (uint8_t) second; // Exact Time 256 -> Day Date Time -> Date Time -> Seconds
+    this->bytesCurrentTime[7] = (uint8_t) (dow == 0 ? 7 : dow); // Exact Time 256 -> Day Date Time -> Day of Week
+    this->bytesCurrentTime[8] = 0b00000000; // Exact Time 256 -> Fractions256
+    this->bytesCurrentTime[9] = 0b00000001; // Adjust Reason: External Reference Time Update
+    pCharacteristic->setValue(this->bytesCurrentTime, sizeof(this->bytesCurrentTime));
 }
 
 void OswServiceTaskBLEServer::FirmwareRevisionCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
@@ -337,45 +337,45 @@ void OswServiceTaskBLEServer::HardwareRevisionCharacteristicCallbacks::onRead(Ni
 void OswServiceTaskBLEServer::StepsTodayCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
     uint32_t stepsToday = OswHal::getInstance()->environment()->getStepsToday();
 
-    this->bytes[0] = (uint8_t) stepsToday;
-    this->bytes[1] = (uint8_t) (stepsToday >> 8);
-    this->bytes[2] = (uint8_t) (stepsToday >> 16);
-    this->bytes[3] = (uint8_t) (stepsToday >> 24);
+    this->bytesStepsToday[0] = (uint8_t) stepsToday;
+    this->bytesStepsToday[1] = (uint8_t) (stepsToday >> 8);
+    this->bytesStepsToday[2] = (uint8_t) (stepsToday >> 16);
+    this->bytesStepsToday[3] = (uint8_t) (stepsToday >> 24);
 
-    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+    pCharacteristic->setValue(this->bytesStepsToday, sizeof(this->bytesStepsToday));
 }
 
 void OswServiceTaskBLEServer::StepsTotalCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
     uint32_t stepsTotal = OswHal::getInstance()->environment()->getStepsTotal();
 
-    this->bytes[0] = (uint8_t) stepsTotal;
-    this->bytes[1] = (uint8_t) (stepsTotal >> 8);
-    this->bytes[2] = (uint8_t) (stepsTotal >> 16);
-    this->bytes[3] = (uint8_t) (stepsTotal >> 24);
+    this->bytesStepsTotal[0] = (uint8_t) stepsTotal;
+    this->bytesStepsTotal[1] = (uint8_t) (stepsTotal >> 8);
+    this->bytesStepsTotal[2] = (uint8_t) (stepsTotal >> 16);
+    this->bytesStepsTotal[3] = (uint8_t) (stepsTotal >> 24);
 
-    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+    pCharacteristic->setValue(this->bytesStepsTotal, sizeof(this->bytesStepsTotal));
 }
 
 void OswServiceTaskBLEServer::StepsTotalWeekCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
     uint32_t stepsTotalWeek = OswHal::getInstance()->environment()->getStepsTotalWeek();
 
-    this->bytes[0] = (uint8_t) stepsTotalWeek;
-    this->bytes[1] = (uint8_t) (stepsTotalWeek >> 8);
-    this->bytes[2] = (uint8_t) (stepsTotalWeek >> 16);
-    this->bytes[3] = (uint8_t) (stepsTotalWeek >> 24);
+    this->bytesStepsTotalWeek[0] = (uint8_t) stepsTotalWeek;
+    this->bytesStepsTotalWeek[1] = (uint8_t) (stepsTotalWeek >> 8);
+    this->bytesStepsTotalWeek[2] = (uint8_t) (stepsTotalWeek >> 16);
+    this->bytesStepsTotalWeek[3] = (uint8_t) (stepsTotalWeek >> 24);
 
-    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+    pCharacteristic->setValue(this->bytesStepsTotalWeek, sizeof(this->bytesStepsTotalWeek));
 }
 #ifdef OSW_FEATURE_STATS_STEPS
 void OswServiceTaskBLEServer::StepsAverageCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
     uint32_t stepsAverage = OswHal::getInstance()->environment()->getStepsAverage();
 
-    this->bytes[0] = (uint8_t) stepsAverage;
-    this->bytes[1] = (uint8_t) (stepsAverage >> 8);
-    this->bytes[2] = (uint8_t) (stepsAverage >> 16);
-    this->bytes[3] = (uint8_t) (stepsAverage >> 24);
+    this->bytesStepsAverage[0] = (uint8_t) stepsAverage;
+    this->bytesStepsAverage[1] = (uint8_t) (stepsAverage >> 8);
+    this->bytesStepsAverage[2] = (uint8_t) (stepsAverage >> 16);
+    this->bytesStepsAverage[3] = (uint8_t) (stepsAverage >> 24);
 
-    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+    pCharacteristic->setValue(this->bytesStepsAverage, sizeof(this->bytesStepsAverage));
 }
 
 void OswServiceTaskBLEServer::StepsDayHistoryCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
@@ -383,13 +383,13 @@ void OswServiceTaskBLEServer::StepsDayHistoryCharacteristicCallbacks::onRead(Nim
     for (uint8_t indexOfWeek = 0; indexOfWeek < 7; indexOfWeek++)
     { 
         uint32_t value = OswHal::getInstance()->environment()->getStepsOnDay(indexOfWeek, false);
-        this->bytes[0 + indexOfWeek * 4] = (uint8_t) value;
-        this->bytes[1 + indexOfWeek * 4] = (uint8_t) (value >> 8);
-        this->bytes[2 + indexOfWeek * 4] = (uint8_t) (value >> 16);
-        this->bytes[3 + indexOfWeek * 4] = (uint8_t) (value >> 24);
+        this->bytesStepsDayHistory[0 + indexOfWeek * 4] = (uint8_t) value;
+        this->bytesStepsDayHistory[1 + indexOfWeek * 4] = (uint8_t) (value >> 8);
+        this->bytesStepsDayHistory[2 + indexOfWeek * 4] = (uint8_t) (value >> 16);
+        this->bytesStepsDayHistory[3 + indexOfWeek * 4] = (uint8_t) (value >> 24);
     }
 
-    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+    pCharacteristic->setValue(this->bytesStepsDayHistory, sizeof(this->bytesStepsDayHistory));
 }
 #endif
 #endif

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -1,0 +1,97 @@
+#ifdef OSW_FEATURE_BLE_SERVER
+#include "./services/OswServiceTaskBLEServer.h"
+#include "osw_hal.h"
+
+#define BATTERY_SERVICE_UUID "0000180F-0000-1000-8000-00805f9b34fb"
+#define BATTERY_LEVEL_CHARACTERISTIC_UUID "00002A19-0000-1000-8000-00805f9b34fb"
+
+void OswServiceTaskBLEServer::setup() {
+    OswServiceTask::setup();
+    this->updateName();
+
+    NimBLEDevice::setSecurityAuth(true, false, false); // support bonding, but no mitm-protection or secure pairing
+    NimBLEDevice::setSecurityIOCap(BLE_HS_IO_DISPLAY_YESNO); // we can display yes/no with a given key to the user
+
+    // Create the BLE Server
+    server = NimBLEDevice::getServer();
+    if(server == nullptr) {
+        OSW_LOG_D("No server found, creating a new one.");
+        server = NimBLEDevice::createServer();
+    }
+    server->setCallbacks(this); // make sure, we are the servers authority
+
+    {
+        // Create the BLE Service
+        serviceBat = server->createService(BATTERY_SERVICE_UUID);
+
+        // Create a BLE Characteristic
+        characteristicBat = serviceBat->createCharacteristic(
+                                BATTERY_LEVEL_CHARACTERISTIC_UUID,
+                                NIMBLE_PROPERTY::READ
+                            );
+        characteristicBat->setCallbacks(&battery);
+
+        // Start the service
+        serviceBat->start();
+    }
+
+    // Start advertising
+    {
+        BLEAdvertising* pAdvertising = BLEDevice::getAdvertising();
+        pAdvertising->addServiceUUID(BATTERY_SERVICE_UUID);
+        pAdvertising->setScanResponse(false);
+        /** Note, this could be left out as that is the default value */
+        pAdvertising->setMinPreferred(0x0);  // set value to 0x00 to not advertise this parameter
+        BLEDevice::startAdvertising();
+    }
+}
+
+void OswServiceTaskBLEServer::loop() {
+
+}
+
+void OswServiceTaskBLEServer::stop() {
+    OswServiceTask::stop();
+
+    BLEDevice::stopAdvertising();
+    serviceBat->removeCharacteristic(characteristicBat, true);
+    server->removeService(serviceBat, true);
+}
+
+void OswServiceTaskBLEServer::updateName() {
+    memset(this->name, 0, 8); // clear the name buffer
+    strncpy(this->name, OswConfigAllKeys::hostname.get().c_str(), 8);
+    NimBLEDevice::init(this->name);
+}
+
+void OswServiceTaskBLEServer::onConnect(BLEServer* pServer) {
+    OSW_LOG_D("A client has connected!");
+}
+
+void OswServiceTaskBLEServer::onDisconnect(BLEServer* pServer) {
+    OSW_LOG_D("A client has disconnected!");
+}
+
+uint32_t OswServiceTaskBLEServer::onPassKeyRequest() {
+    // TODO connecting client asked for a pin to confirm
+    OSW_LOG_I("Server PassKeyRequest: ", 123456);
+    return 123456;
+}
+
+bool OswServiceTaskBLEServer::onConfirmPIN(uint32_t pass_key) {
+    // TODO user must confirm if this is the correct key sent by the other device
+    OSW_LOG_I("The passkey YES/NO number: ", pass_key);
+    return true;
+}
+
+
+void OswServiceTaskBLEServer::BatteryCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
+    // get the current battery level into the inner byte buffer
+    if(OswHal::getInstance()->isCharging()) {
+        byte = 255; // invalid value
+    } else {
+        this->byte = OswHal::getInstance()->getBatteryPercent();
+    }
+    pCharacteristic->setValue(&this->byte, 1);
+}
+#endif

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -382,12 +382,11 @@ void OswServiceTaskBLEServer::StepsDayHistoryCharacteristicCallbacks::onRead(Nim
    
     for (uint8_t indexOfWeek = 0; indexOfWeek < 7; indexOfWeek++)
     { 
-        uint32_t value = OswHal::getInstance()->environment()->getStepsOnDay(indexOfWeek, true);
+        uint32_t value = OswHal::getInstance()->environment()->getStepsOnDay(indexOfWeek, false);
         this->bytes[0 + indexOfWeek * 4] = (uint8_t) value;
         this->bytes[1 + indexOfWeek * 4] = (uint8_t) (value >> 8);
         this->bytes[2 + indexOfWeek * 4] = (uint8_t) (value >> 16);
         this->bytes[3 + indexOfWeek * 4] = (uint8_t) (value >> 24);
-        /* code */
     }
 
     pCharacteristic->setValue(this->bytes, sizeof(this->bytes));

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -2,7 +2,7 @@
 #include "./services/OswServiceTaskBLEServer.h"
 #include "osw_hal.h"
 
-#define BATTERY_SERVICE_UUID                         "0000180F-0000-1000-8000-00805f9b34fb"
+#define BATTERY_SERVICE_UUID                         "0000180f-0000-1000-8000-00805f9b34fb"
 #define BATTERY_LEVEL_CHARACTERISTIC_UUID            "00002A19-0000-1000-8000-00805f9b34fb"
 #define BATTERY_LEVEL_STATUS_CHARACTERISTIC_UUID     "00002bed-0000-1000-8000-00805f9b34fb"
 #define TIME_SERVICE_UUID                            "00001805-0000-1000-8000-00805f9b34fb"

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -55,7 +55,7 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
         OSW_LOG_D("On");
         this->updateName();
 
-        NimBLEDevice::setSecurityAuth(true, false, false); // support bonding, but no mitm-protection or secure pairing
+        NimBLEDevice::setSecurityAuth(true, true, true); // support bonding, with mitm-protection and secure pairing
         NimBLEDevice::setSecurityIOCap(BLE_HS_IO_DISPLAY_YESNO); // we can display yes/no with a given key to the user
 
         // Create the BLE Server
@@ -73,14 +73,14 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
             // Create a BLE Characteristic: "Battery Level"
             this->characteristicBat = serviceBat->createCharacteristic(
                                           BATTERY_LEVEL_CHARACTERISTIC_UUID,
-                                          NIMBLE_PROPERTY::READ
+                                          NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
                                       );
             this->characteristicBat->setCallbacks(new BatteryLevelCharacteristicCallbacks());
 
             // Create a BLE Characteristic: "Battery Level Status"
             this->characteristicBatStat = serviceBat->createCharacteristic(
                                               BATTERY_LEVEL_STATUS_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
                                           );
             this->characteristicBatStat->setCallbacks(new BatteryLevelStatusCharacteristicCallbacks());
 
@@ -95,7 +95,7 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
             // Create a BLE Characteristic: "Current Time"
             this->characteristicCurTime = serviceTime->createCharacteristic(
                                               CURRENT_TIME_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
                                           );
             this->characteristicCurTime->setCallbacks(new CurrentTimeCharacteristicCallbacks());
 
@@ -110,21 +110,21 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
             // Create a BLE Characteristic: "Firmware Revision String"
             this->characteristicFirmRev = serviceDevice->createCharacteristic(
                                               FIRMWARE_REVISION_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
                                           );
             this->characteristicFirmRev->setCallbacks(new FirmwareRevisionCharacteristicCallbacks());
 
             // Create a BLE Characteristic: "Hardware Revision String"
             this->characteristicHardRev = serviceDevice->createCharacteristic(
                                               HARDWARE_REVISION_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
                                           );
             this->characteristicHardRev->setCallbacks(new HardwareRevisionCharacteristicCallbacks());
 
             // Create a BLE Characteristic: "Software Revision String"
             this->characteristicSoftRev = serviceDevice->createCharacteristic(
                                               SOFTWARE_REVISION_CHARACTERISTIC_UUID,
-                                              NIMBLE_PROPERTY::READ
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
                                           );
             this->characteristicSoftRev->setCallbacks(new SoftwareRevisionCharacteristicCallbacks());
 
@@ -141,7 +141,7 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
             pAdvertising->setScanResponse(false);
             /** Note, this could be left out as that is the default value */
             pAdvertising->setMinPreferred(0x0);  // set value to 0x00 to not advertise this parameter
-            BLEDevice::startAdvertising();
+            NimBLEDevice::startAdvertising();
         }
     } else if(!this->enabled and this->server != nullptr) {
         OSW_LOG_D("Off");
@@ -167,11 +167,11 @@ void OswServiceTaskBLEServer::updateName() {
 }
 
 void OswServiceTaskBLEServer::ServerCallbacks::onConnect(BLEServer* pServer) {
-    OSW_LOG_D("A client has connected!");
+    OSW_LOG_D("A client has connected (", pServer->getConnectedCount(), ")!");
 }
 
 void OswServiceTaskBLEServer::ServerCallbacks::onDisconnect(BLEServer* pServer) {
-    OSW_LOG_D("A client has disconnected!");
+    OSW_LOG_D("A client has disconnected (", pServer->getConnectedCount(), ")!");
 }
 
 uint32_t OswServiceTaskBLEServer::ServerCallbacks::onPassKeyRequest() {

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -2,17 +2,23 @@
 #include "./services/OswServiceTaskBLEServer.h"
 #include "osw_hal.h"
 
-#define BATTERY_SERVICE_UUID "0000180F-0000-1000-8000-00805f9b34fb"
-#define BATTERY_LEVEL_CHARACTERISTIC_UUID "00002A19-0000-1000-8000-00805f9b34fb"
-#define BATTERY_LEVEL_STATUS_CHARACTERISTIC_UUID "00002bed-0000-1000-8000-00805f9b34fb"
-#define TIME_SERVICE_UUID "00001805-0000-1000-8000-00805f9b34fb"
-#define CURRENT_TIME_CHARACTERISTIC_UUID "00002a0c-0000-1000-8000-00805f9b34fb"
-#define DEVICE_INFORMATION_SERVICE_UUID "0000180a-0000-1000-8000-00805f9b34fb"
-#define FIRMWARE_REVISION_CHARACTERISTIC_UUID "00002a26-0000-1000-8000-00805f9b34fb"
-#define HARDWARE_REVISION_CHARACTERISTIC_UUID "00002a27-0000-1000-8000-00805f9b34fb"
-#define SOFTWARE_REVISION_CHARACTERISTIC_UUID "00002a28-0000-1000-8000-00805f9b34fb"
-#define OSW_SERVICE_UUID "6ab9b834-3e0b-4770-a938-ebaa58d6b852"
-#define TOAST_CHARACTERISTIC_UUID "9cadf570-4ec8-40b0-a8d3-cfdb4a90940b"
+#define BATTERY_SERVICE_UUID                         "0000180F-0000-1000-8000-00805f9b34fb"
+#define BATTERY_LEVEL_CHARACTERISTIC_UUID            "00002A19-0000-1000-8000-00805f9b34fb"
+#define BATTERY_LEVEL_STATUS_CHARACTERISTIC_UUID     "00002bed-0000-1000-8000-00805f9b34fb"
+#define TIME_SERVICE_UUID                            "00001805-0000-1000-8000-00805f9b34fb"
+#define CURRENT_TIME_CHARACTERISTIC_UUID             "00002a0c-0000-1000-8000-00805f9b34fb"
+#define DEVICE_INFORMATION_SERVICE_UUID              "0000180a-0000-1000-8000-00805f9b34fb"
+#define FIRMWARE_REVISION_CHARACTERISTIC_UUID        "00002a26-0000-1000-8000-00805f9b34fb"
+#define HARDWARE_REVISION_CHARACTERISTIC_UUID        "00002a27-0000-1000-8000-00805f9b34fb"
+#define SOFTWARE_REVISION_CHARACTERISTIC_UUID        "00002a28-0000-1000-8000-00805f9b34fb"
+
+#define OSW_SERVICE_UUID                             "6ab9b834-3e0b-4770-a938-ebaa58d6b852"
+#define TOAST_CHARACTERISTIC_UUID                    "9cadf570-4ec8-40b0-a8d3-cfdb4a90940b"
+#define STEP_COUNT_AVERAGE_CHARACTERISTIC_UUID       "3d27dd91-b714-4fe4-8067-620ff7cf13c0"
+#define STEP_COUNT_TOTAL_CHARACTERISTIC_UUID         "6567e61b-41df-4416-96fc-4e068628bd37"
+#define STEP_COUNT_TOTAL_WEEK_CHARACTERISTIC_UUID    "0b97315f-883b-4e1e-a745-bc2dd14aedb4"
+#define STEP_COUNT_TODAY_CHARACTERISTIC_UUID         "143a6279-67ce-43c2-8db2-082a9fbca140"
+#define STEP_COUNT_DAY_HISTORY_CHARACTERISTIC_UUID   "6b078d24-79ae-4fff-bf3a-2b71dce2b2bb"
 
 void OswServiceTaskBLEServer::setup() {
     OswServiceTask::setup();
@@ -143,6 +149,38 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
                                         );
             this->characteristicToast->setCallbacks(new ToastCharacteristicCallbacks(this));
 
+#if OSW_PLATFORM_ENVIRONMENT_ACCELEROMETER == 1
+            this->characteristicStepCountToday = this->serviceOsw->createCharacteristic(
+                                              STEP_COUNT_TODAY_CHARACTERISTIC_UUID,
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                          );
+            this->characteristicStepCountToday->setCallbacks(new StepsTodayCharacteristicCallbacks());
+
+            this->characteristicStepCountTotal = this->serviceOsw->createCharacteristic(
+                                              STEP_COUNT_TOTAL_CHARACTERISTIC_UUID,
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                          );
+            this->characteristicStepCountTotal->setCallbacks(new StepsTotalCharacteristicCallbacks());
+
+            this->characteristicStepCountTotalWeek = this->serviceOsw->createCharacteristic(
+                                              STEP_COUNT_TOTAL_WEEK_CHARACTERISTIC_UUID,
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                          );
+            this->characteristicStepCountTotalWeek->setCallbacks(new StepsTotalWeekCharacteristicCallbacks());
+#ifdef OSW_FEATURE_STATS_STEPS
+            this->characteristicStepCountAverage = this->serviceOsw->createCharacteristic(
+                                              STEP_COUNT_AVERAGE_CHARACTERISTIC_UUID,
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                          );
+            this->characteristicStepCountAverage->setCallbacks(new StepsAverageCharacteristicCallbacks());
+
+            this->characteristicStepCountHistory = this->serviceOsw->createCharacteristic(
+                                              STEP_COUNT_DAY_HISTORY_CHARACTERISTIC_UUID,
+                                              NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
+                                          );
+            this->characteristicStepCountHistory->setCallbacks(new StepsDayHistoryCharacteristicCallbacks());           // Create a BLE Characteristic: "Hardware Revision String"
+#endif
+#endif
             // Start the service
             this->serviceOsw->start();
         }
@@ -172,6 +210,15 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
         this->serviceDevice->removeCharacteristic(this->characteristicSoftRev, true);
         this->server->removeService(this->serviceDevice, true);
         this->serviceOsw->removeCharacteristic(this->characteristicToast, true);
+#if OSW_PLATFORM_ENVIRONMENT_ACCELEROMETER == 1
+        this->serviceOsw->removeCharacteristic(this->characteristicStepCountToday, true);
+        this->serviceOsw->removeCharacteristic(this->characteristicStepCountTotal, true);
+        this->serviceOsw->removeCharacteristic(this->characteristicStepCountTotalWeek, true);
+#ifdef OSW_FEATURE_STATS_STEPS
+        this->serviceOsw->removeCharacteristic(this->characteristicStepCountAverage, true);
+        this->serviceOsw->removeCharacteristic(this->characteristicStepCountHistory, true);
+#endif
+#endif
         this->server->removeService(this->serviceOsw, true);
         this->server = nullptr;
         NimBLEDevice::deinit(true);
@@ -286,7 +333,67 @@ void OswServiceTaskBLEServer::HardwareRevisionCharacteristicCallbacks::onRead(Ni
     this->value = String(PIO_ENV_NAME);
     pCharacteristic->setValue((uint8_t*) this->value.c_str(), this->value.length());
 }
+#if OSW_PLATFORM_ENVIRONMENT_ACCELEROMETER == 1
+void OswServiceTaskBLEServer::StepsTodayCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
+    uint32_t stepsToday = OswHal::getInstance()->environment()->getStepsToday();
 
+    this->bytes[0] = (uint8_t) stepsToday;
+    this->bytes[1] = (uint8_t) (stepsToday >> 8);
+    this->bytes[2] = (uint8_t) (stepsToday >> 16);
+    this->bytes[3] = (uint8_t) (stepsToday >> 24);
+
+    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+}
+
+void OswServiceTaskBLEServer::StepsTotalCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
+    uint32_t stepsTotal = OswHal::getInstance()->environment()->getStepsTotal();
+
+    this->bytes[0] = (uint8_t) stepsTotal;
+    this->bytes[1] = (uint8_t) (stepsTotal >> 8);
+    this->bytes[2] = (uint8_t) (stepsTotal >> 16);
+    this->bytes[3] = (uint8_t) (stepsTotal >> 24);
+
+    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+}
+
+void OswServiceTaskBLEServer::StepsTotalWeekCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
+    uint32_t stepsTotalWeek = OswHal::getInstance()->environment()->getStepsTotalWeek();
+
+    this->bytes[0] = (uint8_t) stepsTotalWeek;
+    this->bytes[1] = (uint8_t) (stepsTotalWeek >> 8);
+    this->bytes[2] = (uint8_t) (stepsTotalWeek >> 16);
+    this->bytes[3] = (uint8_t) (stepsTotalWeek >> 24);
+
+    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+}
+#ifdef OSW_FEATURE_STATS_STEPS
+void OswServiceTaskBLEServer::StepsAverageCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
+    uint32_t stepsAverage = OswHal::getInstance()->environment()->getStepsAverage();
+
+    this->bytes[0] = (uint8_t) stepsAverage;
+    this->bytes[1] = (uint8_t) (stepsAverage >> 8);
+    this->bytes[2] = (uint8_t) (stepsAverage >> 16);
+    this->bytes[3] = (uint8_t) (stepsAverage >> 24);
+
+    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+}
+
+void OswServiceTaskBLEServer::StepsDayHistoryCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
+   
+    for (uint8_t indexOfWeek = 0; indexOfWeek < 7; indexOfWeek++)
+    { 
+        uint32_t value = OswHal::getInstance()->environment()->getStepsOnDay(indexOfWeek, true);
+        this->bytes[0 + indexOfWeek * 4] = (uint8_t) value;
+        this->bytes[1 + indexOfWeek * 4] = (uint8_t) (value >> 8);
+        this->bytes[2 + indexOfWeek * 4] = (uint8_t) (value >> 16);
+        this->bytes[3 + indexOfWeek * 4] = (uint8_t) (value >> 24);
+        /* code */
+    }
+
+    pCharacteristic->setValue(this->bytes, sizeof(this->bytes));
+}
+#endif
+#endif
 void OswServiceTaskBLEServer::SoftwareRevisionCharacteristicCallbacks::onRead(NimBLECharacteristic* pCharacteristic) {
     this->value = String(GIT_COMMIT_HASH) + " (" + String(GIT_BRANCH_NAME) + ")";
     pCharacteristic->setValue((uint8_t*) this->value.c_str(), this->value.length());

--- a/src/services/OswServiceTaskBLEServer.cpp
+++ b/src/services/OswServiceTaskBLEServer.cpp
@@ -178,7 +178,7 @@ void OswServiceTaskBLEServer::updateBLEConfig() {
                                               STEP_COUNT_DAY_HISTORY_CHARACTERISTIC_UUID,
                                               NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::READ_ENC | NIMBLE_PROPERTY::READ_AUTHEN
                                           );
-            this->characteristicStepCountHistory->setCallbacks(new StepsDayHistoryCharacteristicCallbacks());           // Create a BLE Characteristic: "Hardware Revision String"
+            this->characteristicStepCountHistory->setCallbacks(new StepsDayHistoryCharacteristicCallbacks());
 #endif
 #endif
             // Start the service

--- a/src/services/OswServiceTaskConsole.cpp
+++ b/src/services/OswServiceTaskConsole.cpp
@@ -119,6 +119,7 @@ void OswServiceTaskConsole::runPrompt() {
         } else if (this->m_inputBuffer.find("toast ") == 0 and this->m_inputBuffer.length() > 6) {
             auto arg = this->m_inputBuffer.substr(6);
             std::string toast;
+            // iterate over the string and replace "\n" with the newline character
             for (auto i = 0; i < arg.length(); i++) {
                 if (i + 1 < arg.length() and arg[i] == '\\' and arg[i + 1] == 'n') {
                     toast += '\n';

--- a/src/services/OswServiceTaskConsole.cpp
+++ b/src/services/OswServiceTaskConsole.cpp
@@ -126,7 +126,7 @@ void OswServiceTaskConsole::runPrompt() {
             this->m_configuring = true;
         } else if (this->m_inputBuffer == "help") {
             this->showHelp();
-#ifdef OSW_FEATURE_WIFI
+#if defined(OSW_FEATURE_WIFI) || defined(OSW_FEATURE_BLE_SERVER)
         } else if (this->m_inputBuffer == "hostname") {
             serial->println(OswConfigAllKeys::hostname.get());
 #endif
@@ -175,7 +175,7 @@ void OswServiceTaskConsole::showHelp() {
     } else {
         serial->println("  configure - enter configuration mode");
         serial->println("  help      - show this help");
-#ifdef OSW_FEATURE_WIFI
+#if defined(OSW_FEATURE_WIFI) || defined(OSW_FEATURE_BLE_SERVER)
         serial->println("  hostname  - show the device hostname");
 #endif
         serial->println("  lock      - lock the console");

--- a/src/services/OswServiceTaskConsole.cpp
+++ b/src/services/OswServiceTaskConsole.cpp
@@ -3,6 +3,7 @@
 #include "osw_hal.h"
 #include <services/OswServiceTasks.h>
 #include <services/OswServiceTaskBLEServer.h>
+#include <services/NotifierClient.h>
 
 void OswServiceTaskConsole::setup() {
     OswServiceTask::setup();

--- a/src/services/OswServiceTaskWebserver.cpp
+++ b/src/services/OswServiceTaskWebserver.cpp
@@ -11,6 +11,7 @@
 #include "services/OswServiceTaskWiFi.h"
 #include "services/OswServiceManager.h"
 #include "services/OswServiceTaskWebserver.h"
+#include "services/OswServiceTaskMemMonitor.h"
 
 #include "assets/www/index.html.gz.h"
 #include "assets/www/main.js.gz.h"
@@ -306,6 +307,12 @@ void OswServiceTaskWebserver::enableWebserver() {
         return;
 
     this->m_uiPassword = String(random(10000, 99999));  // Generate a random ui password on loading
+
+    // free memory for the webserver BEFORE starting it (with BLE enabled, we are running out of memory otherwise)
+    {
+        this->m_webserver = (WebServer*) 42; // just to mark it as "active" for the memory monitor
+        OswServiceAllTasks::memory.loop(); // apply it now!
+    }
 
     this->m_webserver = new WebServer(80);
 #ifndef NDEBUG

--- a/src/services/OswServiceTasks.cpp
+++ b/src/services/OswServiceTasks.cpp
@@ -1,6 +1,7 @@
 #include "services/OswServiceTasks.h"
 
 #include "services/OswServiceTaskBLECompanion.h"
+#include "services/OswServiceTaskBLEServer.h"
 #include "services/OswServiceTaskExample.h"
 #include "services/OswServiceTaskGPS.h"
 #include "services/OswServiceTaskMemMonitor.h"
@@ -28,6 +29,9 @@ OswServiceTaskGPS gps;
 OswServiceTaskWiFi wifi;
 OswServiceTaskWebserver webserver;
 #endif
+#ifdef OSW_FEATURE_BLE_SERVER
+OswServiceTaskBLEServer bleServer;
+#endif
 #if OSW_SERVICE_NOTIFIER == 1
 OswServiceTaskNotifier notifier;
 #endif
@@ -52,6 +56,9 @@ OswServiceTask* oswServiceTasks[] = {
 #endif
 #ifdef OSW_FEATURE_WIFI
     & OswServiceAllTasks::wifi, &OswServiceAllTasks::webserver,
+#endif
+#ifdef OSW_FEATURE_BLE_SERVER
+    & OswServiceAllTasks::bleServer,
 #endif
 #if OSW_SERVICE_NOTIFIER == 1
     & OswServiceAllTasks::notifier,


### PR DESCRIPTION
After #409, part of #141 

this is JUST the server, so a device can connect to an OSW and perform a few basic operations

the client will be implemented whenever we have a spec/server for it

checklist:
- [x] config option to start server on boot
- [x] document new flags in docs
- [x] basic ui for
  - [x] binding request
  - [x] connect/disconnect
  - [x] toasts
- [x] services
  - [x] firmware version
  - [x] battery info
  - [x] custom OSW service
