### PR TITLE
Fix compile minor waring

### DIFF
--- a/src/apps/tools/OswAppTutorial.cpp
+++ b/src/apps/tools/OswAppTutorial.cpp
@@ -153,7 +153,9 @@ void OswAppTutorial::onDraw() {
         hal->gfx()->setTextCursor(DISP_W / 2, 120);
         hal->gfx()->print(LANG_TUT_SCR3_TEXT);
 
+#if defined(GPS_EDITION) || defined(GPS_EDITION_ROTATED) || defined(OSW_FEATURE_WIFI)
         short y = 160;
+#endif
         bool anyProblems = false;
 #ifdef OSW_FEATURE_WIFI
         hal->gfx()->setTextCursor(DISP_W / 2, y);


### PR DESCRIPTION
Move variables that are compiled but may not be used due to macros into the scope of the macros.