### PR TITLE
emulator: Don’t require config.h

### DIFF
--- a/src/apps/_experiments/dnatilt.cpp
+++ b/src/apps/_experiments/dnatilt.cpp
@@ -2,7 +2,7 @@
 #if OSW_PLATFORM_ENVIRONMENT_ACCELEROMETER == 1
 #include "./apps/_experiments/dnatilt.h"
 
-#include <config.h>
+#include "config_defaults.h"
 #include <gfx_util.h>
 #include <OswAppV1.h>
 #include <osw_hal.h>

--- a/src/apps/tools/OswAppBLEMediaCtrl.cpp
+++ b/src/apps/tools/OswAppBLEMediaCtrl.cpp
@@ -2,7 +2,7 @@
 #ifdef OSW_FEATURE_BLE_MEDIA_CTRL
 #include "./apps/tools/OswAppBLEMediaCtrl.h"
 
-#include <config.h>
+#include "config_defaults.h"
 #include <gfx_util.h>
 #include <OswAppV1.h>
 #include <osw_hal.h>

--- a/src/apps/tools/OswAppTimeConfig.cpp
+++ b/src/apps/tools/OswAppTimeConfig.cpp
@@ -1,6 +1,6 @@
 #include "./apps/tools/OswAppTimeConfig.h"
 
-#include <config.h>
+#include "config_defaults.h"
 #include <gfx_util.h>
 #include <OswAppV1.h>
 #include <osw_config_keys.h>

--- a/src/apps/watchfaces/OswAppWatchfaceDual.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceDual.cpp
@@ -1,6 +1,6 @@
 #include "./apps/watchfaces/OswAppWatchfaceDual.h"
 
-#include <config.h>
+#include "config_defaults.h"
 #include <gfx_util.h>
 #include <OswAppV1.h>
 #include <osw_config_keys.h>

--- a/src/apps/watchfaces/OswAppWatchfaceFitness.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceFitness.cpp
@@ -5,7 +5,7 @@
 #include "apps/watchfaces/OswAppWatchfaceDigital.h"
 #include "apps/watchfaces/OswAppWatchface.h"
 
-#include <config.h>
+#include "config_defaults.h"
 #include <gfx_util.h>
 #include <OswAppV1.h>
 #include <osw_config_keys.h>

--- a/src/apps/watchfaces/OswAppWatchfaceFitnessAnalog.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceFitnessAnalog.cpp
@@ -8,7 +8,7 @@
 #include "./apps/_experiments/gif_player.h"
 #endif
 
-#include <config.h>
+#include "config_defaults.h"
 #include <gfx_util.h>
 #include <OswAppV1.h>
 #include <osw_config_keys.h>

--- a/src/apps/watchfaces/OswAppWatchfaceMix.cpp
+++ b/src/apps/watchfaces/OswAppWatchfaceMix.cpp
@@ -3,7 +3,7 @@
 #include "./apps/watchfaces/OswAppWatchfaceMix.h"
 #include "./apps/watchfaces/OswAppWatchface.h"
 
-#include <config.h>
+#include "config_defaults.h"
 #include <gfx_util.h>
 #include <OswAppV1.h>
 #include <osw_config_keys.h>


### PR DESCRIPTION
37d7d51ac3ae (2021-07-22) made it so that `config.h` was only required if necessary to override `config_defaults.h`, and ae525053e7cb (2022-10-19) documented that. However, the emulator build still required the presence of `config.h`. This updates remaining files to `#include "config_defaults.h"`, which has the responsibility for conditionally further including `config.h` if present, just like the non-emulator build.