### PR TITLE
Make compatible with newer ESP-Arduino core

### DIFF
--- a/include/OswImage.h
+++ b/include/OswImage.h
@@ -27,5 +27,5 @@ class OswImage {
     const unsigned short width;
     const unsigned short height;
 
-    static void drawCallback(pngle_t* pngle, unsigned int x, unsigned int y, unsigned int w, unsigned int h, unsigned char rgba[4]);
+    static void drawCallback(pngle_t* pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]);
 };

--- a/include/gfx_2d.h
+++ b/include/gfx_2d.h
@@ -239,7 +239,7 @@ class Graphics2D {
     }
 
     inline void drawTick(int16_t cx, int16_t cy, int16_t r1, int16_t r2, int angle, uint16_t color) {
-        drawLine(rpx(cx, r1, angle), rpy(cy, r1, angle), rpx(cx, r2, angle), rpy(cy, r2, angle), color);
+        drawLine(rpx(cx, r1, static_cast<int32_t>(angle)), rpy(cy, r1, static_cast<int32_t>(angle)), rpx(cx, r2, static_cast<int32_t>(angle)), rpy(cy, r2, static_cast<int32_t>(angle)), color);
     }
 
     inline void drawTickAA(int16_t cx, int16_t cy, int16_t r1, int16_t r2, float angle, uint16_t color) {

--- a/src/OswImage.cpp
+++ b/src/OswImage.cpp
@@ -57,7 +57,7 @@ void OswImage::draw(Graphics2D* gfx, int x, int y, float scale, Alignment xAlign
     pngle_destroy(pngle);
 }
 
-void OswImage::drawCallback(pngle_t* pngle, unsigned int x, unsigned int y, unsigned int w, unsigned int h, unsigned char rgba[4]) {
+void OswImage::drawCallback(pngle_t* pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]) {
     const unsigned char r = rgba[0];  // 0 - 255
     const unsigned char g = rgba[1];  // 0 - 255
     const unsigned char b = rgba[2];  // 0 - 255

--- a/src/gfx_2d.cpp
+++ b/src/gfx_2d.cpp
@@ -1387,13 +1387,13 @@ void Graphics2D::drawNTicksAA(int16_t cx, int16_t cy, int16_t r1, int16_t r2, in
         const float deltaAngle = 360.0f / nTicks;
         for (int h = nTicks-1; h >= 0; --h) {
             if (h % skip_every_nth != 0)
-                drawTickAA(cx, cy, r1, r2, h * deltaAngle, color);
+                drawTickAA(cx, cy, r1, r2, static_cast<float>(h) * deltaAngle, color);
         }
     } else {
         const int deltaAngle = 360 / nTicks;
         for (int h = nTicks-1; h >= 0; --h) {
             if (h % skip_every_nth != 0)
-                drawTickAA(cx, cy, r1, r2, h * deltaAngle, color);
+                drawTickAA(cx, cy, r1, r2, static_cast<float>(h) * deltaAngle, color);
         }
     }
 }

--- a/src/hal/display.cpp
+++ b/src/hal/display.cpp
@@ -72,9 +72,14 @@ void OswHal::setupDisplay(bool fromLightSleep) {
 
     // Configure backlight pin as early as possible to avoid flickering on startup
 #if OSW_PLATFORM_HARDWARE_DISPLAY_LED != 0
+#if ESP_ARDUINO_VERSION_MAJOR < 3
     ledcAttachPin(OSW_PLATFORM_HARDWARE_DISPLAY_LED, 1);
     ledcSetup(1, 12000, 8);  // 12 kHz PWM, 8-bit resolution
     ledcWrite(1, 0); // force off initially
+#else
+    ledcAttach(OSW_PLATFORM_HARDWARE_DISPLAY_LED, 12000, 8);
+    ledcWrite(OSW_PLATFORM_HARDWARE_DISPLAY_LED, 0); // force off initially
+#endif
 #else
 #ifndef OSW_EMULATOR // meh, the emulator ignores this for now...
 #warning "Display LED pin unconfigured; can't control backlight brightness"
@@ -109,7 +114,11 @@ void OswHal::stopDisplay(bool toLightSleep) {
     }
 
 #if OSW_PLATFORM_HARDWARE_DISPLAY_LED != 0
+#if ESP_ARDUINO_VERSION_MAJOR < 3
     ledcDetachPin(OSW_PLATFORM_HARDWARE_DISPLAY_LED);
+#else
+    ledcDetach(OSW_PLATFORM_HARDWARE_DISPLAY_LED);
+#endif
     // just pull down the backlight pin
     pinMode(OSW_PLATFORM_HARDWARE_DISPLAY_LED, OUTPUT);
     digitalWrite(OSW_PLATFORM_HARDWARE_DISPLAY_LED, LOW);
@@ -149,7 +158,11 @@ void OswHal::displayOn() {
 void OswHal::setBrightness(uint8_t b, bool storeToNVS) {
     _brightness = b;
 #if OSW_PLATFORM_HARDWARE_DISPLAY_LED != 0
+#if ESP_ARDUINO_VERSION_MAJOR < 3
     ledcWrite(1, _brightness);
+#else
+    ledcWrite(OSW_PLATFORM_HARDWARE_DISPLAY_LED, _brightness);
+#endif
 #endif
     if(storeToNVS) {
         OswConfig::getInstance()->enableWrite();
@@ -202,7 +215,11 @@ uint8_t OswHal::screenBrightness(bool checkHardware) {
 
     if(checkHardware) {
 #if OSW_PLATFORM_HARDWARE_DISPLAY_LED != 0
+#if ESP_ARDUINO_VERSION_MAJOR < 3
         screen_brightness = ledcRead(1);
+#else
+        screen_brightness = ledcRead(OSW_PLATFORM_HARDWARE_DISPLAY_LED);
+#endif
 #endif
         _brightness = screen_brightness;
     }


### PR DESCRIPTION
This updates the codebase for compatibility with
https://github.com/pioarduino/platform-espressif32 55.03.35, which in turn uses https://github.com/espressif/arduino-esp32 3.3.5. An additional change along the lines of
https://github.com/T-vK/ESP32-BLE-Keyboard/pull/382 is needed to make lib/ESP32-BLE-Keyboard compatibile as well.

This does not change the platform definition, which remains at https://github.com/platformio/platform-espressif32 6.8.1, using https://github.com/espressif/arduino-esp32 2.0.17. All changed code is correct regardless of Arduino-ESP version, and all changed code is compatible with both versions.