### PR TITLE
gfx: fix drawing bugs in drawFrame and fillCircleAA

### DIFF
--- a/include/gfx_2d.h
+++ b/include/gfx_2d.h
@@ -221,7 +221,7 @@ class Graphics2D {
                       int16_t start_angle = -1, int16_t end_angle = -1);
 
     inline void fillCircleAA(int16_t off_x, int16_t off_y, int16_t r, uint16_t color) {
-        drawCircleAA(off_x, off_y, r, r-1, color);
+        drawCircleAA(off_x, off_y, r, r, color);
     }
 
     void _fillCircleSection(uint16_t x, uint16_t y, uint16_t x0, uint16_t y0, uint16_t color, CIRC_OPT option);

--- a/src/gfx_2d.cpp
+++ b/src/gfx_2d.cpp
@@ -202,9 +202,9 @@ void Graphics2D::drawVLine(int32_t x, int32_t y, uint16_t h, uint16_t color) {
 
 void Graphics2D::drawFrame(int32_t x, int32_t y, uint16_t w, uint16_t h, uint16_t color) {
     drawHLine(x, y, w, color);
-    drawHLine(x, y + h, w, color);
+    drawHLine(x, y + h - 1, w, color);
     drawVLine(x, y, h, color);
-    drawVLine(x + w, y, h, color);
+    drawVLine(x + w - 1, y, h, color);
 }
 
 void Graphics2D::fillFrame(int32_t x0, int32_t y0, uint16_t w, uint16_t h, uint16_t color) {


### PR DESCRIPTION
`Graphics2D::drawFrame` and `Graphics2D::fillCircleAA` were affected by distinct off-by-one errors that were causing them to draw unfilled rectangles and filled anti-aliased circles incorrectly.