### PR TITLE
 Fix OswUI::stopProgress() never freeing the progress bar

### DIFF
--- a/src/osw_ui.cpp
+++ b/src/osw_ui.cpp
@@ -221,7 +221,7 @@ OswUI::OswUIProgress* OswUI::getProgressBar() {
 }
 
 void OswUI::stopProgress() {
-    if (this->getProgressActive())
+    if (!this->getProgressActive())
         return;
     this->mProgressText = "";
     delete this->mProgressBar;


### PR DESCRIPTION
Invert condition in stopProgress to check inactive state